### PR TITLE
WinUIBackend issues fix

### DIFF
--- a/Sources/Gtk3/Callbacks/Signals.swift
+++ b/Sources/Gtk3/Callbacks/Signals.swift
@@ -26,16 +26,14 @@ func connectSignal<T>(
     data: UnsafeRawPointer,
     connectFlags: ConnectFlags = .after,
     handler: @escaping GCallback
-) -> UInt {
-    return UInt(
-        g_signal_connect_data(
-            instance,
-            name,
-            handler,
-            data.cast(),
-            nil,
-            connectFlags.toGConnectFlags()
-        )
+) -> gulong {
+    return g_signal_connect_data(
+        instance,
+        name,
+        handler,
+        data.cast(),
+        nil,
+        connectFlags.toGConnectFlags()
     )
 }
 
@@ -45,12 +43,10 @@ func connectSignal<T>(
     name: String,
     connectFlags: ConnectFlags = .after,
     handler: @escaping GCallback
-) -> UInt {
-    return .init(
-        g_signal_connect_data(instance, name, handler, nil, nil, connectFlags.toGConnectFlags())
-    )
+) -> gulong {
+    return g_signal_connect_data(instance, name, handler, nil, nil, connectFlags.toGConnectFlags())
 }
 
-func disconnectSignal<T>(_ instance: UnsafeMutablePointer<T>?, handlerId: UInt) {
-    g_signal_handler_disconnect(instance, .init(handlerId))
+func disconnectSignal<T>(_ instance: UnsafeMutablePointer<T>?, handlerId: gulong) {
+    g_signal_handler_disconnect(instance, handlerId)
 }

--- a/Sources/Gtk3/GObject.swift
+++ b/Sources/Gtk3/GObject.swift
@@ -33,7 +33,7 @@ open class GObject: GObjectRepresentable {
         g_object_unref(gobjectPointer)
     }
 
-    private var signals: [(UInt, Any)] = []
+    private var signals: [(gulong, Any)] = []
 
     open func registerSignals() {}
 

--- a/Sources/Gtk3Backend/Gtk3Backend.swift
+++ b/Sources/Gtk3Backend/Gtk3Backend.swift
@@ -1349,9 +1349,16 @@ public final class Gtk3Backend:
         window: Window?,
         resultHandler handleResult: @escaping (DialogResult<[URL]>) -> Void
     ) {
+        let action: FileChooserAction = switch openDialogOptions.singleKindSelectionMode {
+            case .files:
+                .open
+            case .directories:
+                .selectFolder
+        }
+
         showFileChooserDialog(
             fileDialogOptions: fileDialogOptions,
-            action: .open,
+            action: action,
             configure: { chooser in
                 chooser.selectMultiple = openDialogOptions.allowMultipleSelections
             },

--- a/Sources/Gtk3CHelpers/gtk_custom_root_widget.c
+++ b/Sources/Gtk3CHelpers/gtk_custom_root_widget.c
@@ -29,7 +29,7 @@ GtkSizeRequestMode gtk_custom_root_widget_size_request_mode(GtkWidget *widget) {
     return GTK_SIZE_REQUEST_HEIGHT_FOR_WIDTH;
 }
 
-int max(int a, int b) {
+static int scui_max(int a, int b) {
     if (a > b) {
         return a;
     } else {
@@ -44,7 +44,7 @@ void gtk_custom_root_widget_get_preferred_width(
 ) {
     GtkCustomRootWidget *root_widget = GTK_CUSTOM_ROOT_WIDGET(widget);
     *minimum = root_widget->minimum_width;
-    *natural = max(root_widget->natural_width, root_widget->minimum_width);
+    *natural = scui_max(root_widget->natural_width, root_widget->minimum_width);
 }
 
 void gtk_custom_root_widget_get_preferred_height(
@@ -54,7 +54,7 @@ void gtk_custom_root_widget_get_preferred_height(
 ) {
     GtkCustomRootWidget *root_widget = GTK_CUSTOM_ROOT_WIDGET(widget);
     *minimum = root_widget->minimum_height;
-    *natural = max(root_widget->natural_height, root_widget->minimum_height);
+    *natural = scui_max(root_widget->natural_height, root_widget->minimum_height);
 }
 
 void gtk_custom_root_widget_size_allocate(

--- a/Sources/GtkBackend/GtkBackend.swift
+++ b/Sources/GtkBackend/GtkBackend.swift
@@ -1448,9 +1448,16 @@ public final class GtkBackend:
         window: Window?,
         resultHandler handleResult: @escaping (DialogResult<[URL]>) -> Void
     ) {
+        let action: FileChooserAction = switch openDialogOptions.singleKindSelectionMode {
+            case .files:
+                .open
+            case .directories:
+                .selectFolder
+        }
+
         showFileChooserDialog(
             fileDialogOptions: fileDialogOptions,
-            action: .open,
+            action: action,
             configure: { chooser in
                 chooser.selectMultiple = openDialogOptions.allowMultipleSelections
             },

--- a/Sources/SwiftCrossUI/Backend/OpenDialogOptions.swift
+++ b/Sources/SwiftCrossUI/Backend/OpenDialogOptions.swift
@@ -1,5 +1,14 @@
 /// Options for 'open file' dialogs.
 public struct OpenDialogOptions {
+    /// The selection mode to use on backends that can only select one kind of
+    /// item per dialog.
+    public enum SingleKindSelectionMode: Equatable {
+        /// Select files.
+        case files
+        /// Select directories (folders).
+        case directories
+    }
+
     /// Whether to allow selecting files.
     public var allowSelectingFiles: Bool
     /// Whether to allow selecting directories (folders).
@@ -7,4 +16,19 @@ public struct OpenDialogOptions {
     /// Whether to allow multiple selections. If `false`, the user can only
     /// select one item.
     public var allowMultipleSelections: Bool
+
+    /// The mode to use on backends that can only select files or directories,
+    /// but not both in the same dialog.
+    ///
+    /// When both files and directories are enabled, files are preferred to
+    /// preserve the behavior of existing GTK and WinUI backends.
+    public var singleKindSelectionMode: SingleKindSelectionMode {
+        if allowSelectingFiles {
+            return .files
+        } else if allowSelectingDirectories {
+            return .directories
+        } else {
+            preconditionFailure("Open dialogs must allow selecting files or directories")
+        }
+    }
 }

--- a/Sources/WinUIBackend/Console.swift
+++ b/Sources/WinUIBackend/Console.swift
@@ -1,6 +1,10 @@
 import Foundation
 import WinSDK
 
+#if canImport(CRT)
+    import CRT
+#endif
+
 extension WinUIBackend {
     /// Attaches the app's standard IO streams to the parent's console.
     ///
@@ -25,7 +29,7 @@ extension WinUIBackend {
         guard
             freopen_s(&fp, "NUL:", "r", stdin) == 0,
             freopen_s(&fp, "NUL:", "w", stdout) == 0,
-            freopen_s(&fp, "NUL:", "w", stdout) == 0,
+            freopen_s(&fp, "NUL:", "w", stderr) == 0,
             FreeConsole()
         else {
             throw Error(message: "Failed to release existing console")
@@ -37,11 +41,107 @@ extension WinUIBackend {
         var fp = UnsafeMutablePointer<FILE>?.none
         guard
             freopen_s(&fp, "CONIN$", "r", stdin) == 0,
-            freopen_s(&fp, "CONOUT$", "w", stdout) == 0,
             freopen_s(&fp, "CONOUT$", "w", stderr) == 0
         else {
             throw Error(message: "Failed to redirect console IO")
         }
+        try redirectFilteredStandardOutput()
+    }
+
+    /// Redirects stdout into a pipe drained by a background thread that
+    /// filters out noise before writing to the console.
+    ///
+    /// Microsoft.UI.Xaml.dll from WindowsAppSDK 1.5 preview prints backdrop
+    /// debugging messages (BVI-*, rcBackdropLocal=, and bare matrix/rect
+    /// value lines) straight to stdout whenever an acrylic backdrop
+    /// re-renders, and apps have no switch to turn them off. stderr is left
+    /// attached directly to the console so that crash output can't get lost
+    /// in the pipe. Remove this filter once we're on a stable WindowsAppSDK
+    /// (#204).
+    private static func redirectFilteredStandardOutput() throws {
+        var pipeEnds = [CInt](repeating: 0, count: 2)
+        guard _pipe(&pipeEnds, 65536, _O_BINARY) == 0 else {
+            throw Error(message: "Failed to create console filter pipe")
+        }
+        let readEnd = pipeEnds[0]
+        let writeEnd = pipeEnds[1]
+
+        guard _dup2(writeEnd, _fileno(stdout)) == 0 else {
+            throw Error(message: "Failed to redirect stdout to console filter pipe")
+        }
+        // The pipe isn't a console, so the CRT switches stdout to full
+        // buffering; disable buffering so output flows through immediately.
+        setvbuf(stdout, nil, _IONBF, 0)
+
+        // Cover code that writes directly to GetStdHandle(STD_OUTPUT_HANDLE)
+        // as well.
+        SetStdHandle(
+            STD_OUTPUT_HANDLE,
+            UnsafeMutableRawPointer(bitPattern: _get_osfhandle(writeEnd))
+        )
+
+        var consoleFile = UnsafeMutablePointer<FILE>?.none
+        guard fopen_s(&consoleFile, "CONOUT$", "w") == 0, let console = consoleFile else {
+            throw Error(message: "Failed to open console for filtered output")
+        }
+        let consoleAddress = UInt(bitPattern: console)
+
+        Thread.detachNewThread {
+            let console = UnsafeMutablePointer<FILE>(bitPattern: consoleAddress)!
+            var buffer = [UInt8](repeating: 0, count: 4096)
+            var pending = ""
+            var lastLineWasNoise = false
+            while true {
+                let count = _read(readEnd, &buffer, UInt32(buffer.count))
+                guard count > 0 else { break }
+                pending += String(decoding: buffer[0..<Int(count)], as: UTF8.self)
+                while let newlineIndex = pending.firstIndex(of: "\n") {
+                    var line = String(pending[..<newlineIndex])
+                    pending = String(pending[pending.index(after: newlineIndex)...])
+                    if line.hasSuffix("\r") {
+                        line.removeLast()
+                    }
+                    if isBackdropDebugNoise(line, afterNoiseLine: lastLineWasNoise) {
+                        lastLineWasNoise = true
+                        continue
+                    }
+                    lastLineWasNoise = false
+                    fputs(line + "\n", console)
+                    fflush(console)
+                }
+            }
+
+            if !pending.isEmpty {
+                if pending.hasSuffix("\r") {
+                    pending.removeLast()
+                }
+                if !isBackdropDebugNoise(pending, afterNoiseLine: lastLineWasNoise) {
+                    fputs(pending, console)
+                    fflush(console)
+                }
+            }
+        }
+    }
+
+    /// Decides whether a single output line is WinUI backdrop debugging noise.
+    private nonisolated static func isBackdropDebugNoise(
+        _ line: String,
+        afterNoiseLine: Bool
+    ) -> Bool {
+        // The noise blocks are interleaved with blank lines; drop blank lines
+        // that directly follow a noise line.
+        if line.isEmpty {
+            return afterNoiseLine
+        }
+        if line.hasPrefix("BVI-") || line.hasPrefix("rcBackdropLocal=") {
+            return true
+        }
+        // Bare matrix/rect value lines contain only digits and light
+        // punctuation, e.g. "(1.25, 0.00, 0.00, 0.00), ..." or
+        // "0.00, 0.00, 12.00, 339.20 (12.00 x 339.20)". Only filter them
+        // after an explicit backdrop noise prefix so normal numeric stdout
+        // such as "12345" still reaches the console.
+        return afterNoiseLine && line.allSatisfy { "0123456789.,-() x".contains($0) }
     }
 
     /// Adjusts the size of the app's console output buffer.

--- a/Sources/WinUIBackend/WinUIBackend+Sheets.swift
+++ b/Sources/WinUIBackend/WinUIBackend+Sheets.swift
@@ -10,6 +10,13 @@ import WinSDK
 extension WinUIBackend: BackendFeatures.Sheets {
     public class Sheet: ContentDialog {
         var dismissHandler: (() -> Void)?
+        var nestedSheet: Sheet?
+        weak var parentSheet: Sheet?
+        weak var window: Window?
+        var isProgrammaticDismissal = false
+        var isSuspendedForNestedSheet = false
+        var pendingNestedPresentation: Sheet?
+        var isPresenting = false
     }
 
     public func createSheet(content: Widget) -> Sheet {
@@ -33,7 +40,6 @@ extension WinUIBackend: BackendFeatures.Sheets {
         accelerator.invoked.addHandler { [weak sheet] _, _ in
             guard let sheet else { return }
             try! sheet.hide()
-            sheet.dismissHandler?()
         }
         sheet.keyboardAccelerators.append(accelerator)
         sheet.keyboardAcceleratorPlacementMode = .hidden
@@ -86,28 +92,93 @@ extension WinUIBackend: BackendFeatures.Sheets {
         window: Window,
         parentSheet: Sheet?
     ) {
+        sheet.window = window
+        sheet.parentSheet = parentSheet
+
+        if let parentSheet {
+            parentSheet.nestedSheet = sheet
+            parentSheet.pendingNestedPresentation = sheet
+            parentSheet.isSuspendedForNestedSheet = true
+            do {
+                try parentSheet.hide()
+            } catch {
+                print("Error: \(error)")
+                presentSheetNow(sheet, window: window)
+            }
+            return
+        }
+
+        presentSheetNow(sheet, window: window)
+    }
+
+    private func presentSheetNow(_ sheet: Sheet, window: Window) {
         sheet.xamlRoot = window.content.xamlRoot
+        sheet.window = window
+        sheet.isPresenting = true
         do {
             let promise = try sheet.showAsync()!
-            promise.completed = { [weak sheet] _, status in
-                guard let sheet, status == .completed else {
+            promise.completed = { [weak self, weak sheet, weak window] _, status in
+                guard let self, let sheet, status == .completed else {
+                    return
+                }
+
+                sheet.isPresenting = false
+
+                if sheet.isSuspendedForNestedSheet {
+                    sheet.isSuspendedForNestedSheet = false
+                    if
+                        let nestedSheet = sheet.pendingNestedPresentation,
+                        let window = sheet.window ?? window
+                    {
+                        sheet.pendingNestedPresentation = nil
+                        self.presentSheetNow(nestedSheet, window: window)
+                    }
+                    return
+                }
+
+                let wasProgrammaticDismissal = sheet.isProgrammaticDismissal
+                sheet.isProgrammaticDismissal = false
+
+                if let parentSheet = sheet.parentSheet {
+                    parentSheet.nestedSheet = nil
+                    sheet.parentSheet = nil
+
+                    if let window = parentSheet.window ?? window {
+                        self.presentSheetNow(parentSheet, window: window)
+                    }
+                }
+
+                guard !wasProgrammaticDismissal else {
                     return
                 }
 
                 sheet.dismissHandler?()
             }
         } catch {
-            // Force tries don't print properly in some Windows environments, and this
-            // is a particularly useful error to have access to, because there are legitimate
-            // edge cases under which this could be triggered
+            // WinUI only allows a single ContentDialog per XamlRoot. Nested
+            // sheets suspend their parent before presenting; any error that
+            // still reaches this point should be visible without crashing the
+            // process.
             print("Error: \(error)")
-            fatalError("\(error)")
+            sheet.isPresenting = false
         }
     }
 
     public func dismissSheet(_ sheet: Sheet, window: Window, parentSheet: Sheet?) {
-        print("Dismissing sheet programmatically")
-        try! sheet.hide()
+        if let nestedSheet = sheet.nestedSheet {
+            dismissSheet(nestedSheet, window: window, parentSheet: sheet)
+            nestedSheet.dismissHandler?()
+        }
+
+        sheet.isProgrammaticDismissal = true
+        sheet.isSuspendedForNestedSheet = false
+        sheet.pendingNestedPresentation = nil
+        parentSheet?.nestedSheet = nil
+        do {
+            try sheet.hide()
+        } catch {
+            print("Error: \(error)")
+        }
     }
 
     public func size(ofSheet sheet: Sheet) -> SIMD2<Int> {

--- a/Sources/WinUIBackend/WinUIBackend+TextField.swift
+++ b/Sources/WinUIBackend/WinUIBackend+TextField.swift
@@ -12,7 +12,13 @@ extension WinUIBackend {
         let textField = TextBox()
         textField.textChanged.addHandler { [weak internalState] _, _ in
             guard let internalState else { return }
-            internalState.textFieldChangeActions[ObjectIdentifier(textField)]?(textField.text)
+            let identifier = ObjectIdentifier(textField)
+            let text = textField.text
+            guard internalState.textFieldContents[identifier] != text else {
+                return
+            }
+            internalState.textFieldContents[identifier] = text
+            internalState.textFieldChangeActions[identifier]?(text)
         }
         textField.keyUp.addHandler { [weak internalState] _, event in
             guard let internalState else { return }
@@ -41,7 +47,13 @@ extension WinUIBackend {
     }
 
     public func setContent(ofTextField textField: Widget, to content: String) {
-        (textField as! TextBox).text = content
+        let textField = textField as! TextBox
+        let identifier = ObjectIdentifier(textField)
+        internalState.textFieldContents[identifier] = content
+        guard textField.text != content else {
+            return
+        }
+        textField.text = content
     }
 
     public func getContent(ofTextField textField: Widget) -> String {
@@ -56,9 +68,13 @@ extension WinUIBackend {
         let secureField = PasswordBox()
         secureField.passwordChanged.addHandler { [weak internalState] _, _ in
             guard let internalState else { return }
-            internalState.textFieldChangeActions[ObjectIdentifier(secureField)]?(
-                secureField.password
-            )
+            let identifier = ObjectIdentifier(secureField)
+            let password = secureField.password
+            guard internalState.textFieldContents[identifier] != password else {
+                return
+            }
+            internalState.textFieldContents[identifier] = password
+            internalState.textFieldChangeActions[identifier]?(password)
         }
         secureField.keyUp.addHandler { [weak internalState] _, event in
             guard let internalState else { return }
@@ -87,7 +103,13 @@ extension WinUIBackend {
     }
 
     public func setContent(ofSecureField secureField: Widget, to content: String) {
-        (secureField as! PasswordBox).password = content
+        let secureField = secureField as! PasswordBox
+        let identifier = ObjectIdentifier(secureField)
+        internalState.textFieldContents[identifier] = content
+        guard secureField.password != content else {
+            return
+        }
+        secureField.password = content
     }
 
     public func getContent(ofSecureField secureField: Widget) -> String {

--- a/Sources/WinUIBackend/WinUIBackend.swift
+++ b/Sources/WinUIBackend/WinUIBackend.swift
@@ -1582,6 +1582,30 @@ public final class WinUIBackend:
         window: Window?,
         resultHandler handleResult: @escaping (DialogResult<[URL]>) -> Void
     ) {
+        switch openDialogOptions.singleKindSelectionMode {
+            case .files:
+                showFileOpenDialog(
+                    fileDialogOptions: fileDialogOptions,
+                    openDialogOptions: openDialogOptions,
+                    window: window,
+                    resultHandler: handleResult
+                )
+            case .directories:
+                showFolderOpenDialog(
+                    fileDialogOptions: fileDialogOptions,
+                    openDialogOptions: openDialogOptions,
+                    window: window,
+                    resultHandler: handleResult
+                )
+        }
+    }
+
+    private func showFileOpenDialog(
+        fileDialogOptions: FileDialogOptions,
+        openDialogOptions: OpenDialogOptions,
+        window: Window?,
+        resultHandler handleResult: @escaping (DialogResult<[URL]>) -> Void
+    ) {
         let picker = FileOpenPicker()
 
         let window = window ?? windows[0]
@@ -1621,6 +1645,42 @@ public final class WinUIBackend:
                 }
                 handleResult(result)
             }
+        }
+    }
+
+    private func showFolderOpenDialog(
+        fileDialogOptions: FileDialogOptions,
+        openDialogOptions: OpenDialogOptions,
+        window: Window?,
+        resultHandler handleResult: @escaping (DialogResult<[URL]>) -> Void
+    ) {
+        precondition(
+            !openDialogOptions.allowMultipleSelections,
+            "WinUIBackend does not support selecting multiple folders"
+        )
+
+        let picker = FolderPicker()
+
+        let window = window ?? windows[0]
+        let hwnd = window.getHWND()!
+        let interface: SwiftIInitializeWithWindow = try! picker.thisPtr.QueryInterface()
+        try! interface.initialize(with: hwnd)
+
+        picker.commitButtonText = fileDialogOptions.defaultButtonLabel
+        picker.fileTypeFilter.append("*")
+
+        let promise = try! picker.pickSingleFolderAsync()!
+        promise.completed = { operation, status in
+            let result: DialogResult<[URL]> = Self.handleAsyncOperationCompletion(
+                operation,
+                status
+            ) { result in
+                let folder = URL(fileURLWithPath: result.path)
+                return .success([folder])
+            } onFailure: {
+                return .cancelled
+            }
+            handleResult(result)
         }
     }
 

--- a/Sources/WinUIBackend/WinUIBackend.swift
+++ b/Sources/WinUIBackend/WinUIBackend.swift
@@ -152,7 +152,8 @@ public final class WinUIBackend:
     nonisolated(unsafe) private var dispatcherQueue: WinAppSDK.DispatcherQueue?
     /// WinUI only allows one dialog at a time (subsequent dialogs throw
     /// exceptions), so we limit ourselves.
-    private var dialogSemaphore = DispatchSemaphore(value: 1)
+    private var isDialogPresented = false
+    private var queuedDialogActions: [() -> Void] = []
 
     private var windows: [Window] = []
 
@@ -1561,34 +1562,79 @@ public final class WinUIBackend:
         window: Window?,
         responseHandler handleResponse: @escaping (Int) -> Void
     ) {
-        // WinUI only allows one dialog at a time so we limit ourselves using
-        // a semaphore.
         guard let window = window ?? windows.first else {
             logger.warning("WinUI can't show alert without window")
             return
         }
 
-        alert.xamlRoot = window.content.xamlRoot
-        dialogSemaphore.wait()
-        let promise = try! alert.showAsync()!
-        promise.completed = { operation, status in
-            self.dialogSemaphore.signal()
-            guard
-                status == .completed,
-                let operation,
-                let result = try? operation.getResults()
-            else {
+        enqueueDialogPresentation {
+            guard let xamlRoot = window.content.xamlRoot else {
+                logger.warning("WinUI can't show alert before window XamlRoot is available")
+                self.finishDialogPresentation()
+                handleResponse(0)
                 return
             }
-            let index =
-                switch result {
-                    case .primary: 0
-                    case .secondary: 1
-                    case .none: 2
-                    default:
-                        fatalError("WinUIBackend: Invalid dialog response")
+
+            alert.xamlRoot = xamlRoot
+
+            do {
+                guard let promise = try alert.showAsync() else {
+                    logger.warning("WinUI alert showAsync returned nil")
+                    self.finishDialogPresentation()
+                    handleResponse(0)
+                    return
                 }
-            handleResponse(index)
+
+                promise.completed = { operation, status in
+                    self.runInMainThread {
+                        defer {
+                            self.finishDialogPresentation()
+                        }
+
+                        guard
+                            status == .completed,
+                            let operation,
+                            let result = try? operation.getResults()
+                        else {
+                            handleResponse(0)
+                            return
+                        }
+
+                        let index =
+                            switch result {
+                                case .primary: 0
+                                case .secondary: 1
+                                case .none: 2
+                                default:
+                                    fatalError("WinUIBackend: Invalid dialog response")
+                            }
+                        handleResponse(index)
+                    }
+                }
+            } catch {
+                logger.warning("WinUI failed to show alert: \(error)")
+                self.finishDialogPresentation()
+                handleResponse(0)
+                return
+            }
+        }
+    }
+
+    private func enqueueDialogPresentation(_ action: @escaping () -> Void) {
+        if isDialogPresented {
+            queuedDialogActions.append(action)
+        } else {
+            isDialogPresented = true
+            action()
+        }
+    }
+
+    private func finishDialogPresentation() {
+        if queuedDialogActions.isEmpty {
+            isDialogPresented = false
+        } else {
+            let nextAction = queuedDialogActions.removeFirst()
+            nextAction()
         }
     }
 

--- a/Sources/WinUIBackend/WinUIBackend.swift
+++ b/Sources/WinUIBackend/WinUIBackend.swift
@@ -145,6 +145,8 @@ public final class WinUIBackend:
         var sliderChangeActions: [ObjectIdentifier: (Double) -> Void] = [:]
         var textFieldChangeActions: [ObjectIdentifier: (String) -> Void] = [:]
         var textFieldSubmitActions: [ObjectIdentifier: () -> Void] = [:]
+        var textFieldContents: [ObjectIdentifier: String] = [:]
+        var textEditorContents: [ObjectIdentifier: String] = [:]
     }
     private var rootEnvironmentChangeHandler: (@Sendable @MainActor () -> Void)?
 
@@ -653,8 +655,17 @@ public final class WinUIBackend:
             // https://github.com/microsoft/microsoft-ui-xaml/blob/d37afef65a0fc3219ba6b349301d685099fb129d/src/controls/dev/CommonStyles/CheckBox_themeresources.xaml#L270
             return SIMD2(20, 20)
         } else if let picker = widget as? CustomComboBox, picker.padding == noPadding {
+            // Pickers can be measured before their options are populated. Use
+            // WinUI's minimum picker height and a small default width until a
+            // real label exists.
+            guard !picker.options.isEmpty else {
+                return SIMD2(50, 32)
+            }
             let label = TextBlock()
-            label.text = picker.options[Int(max(picker.selectedIndex, 0))]
+            // A ComboBox can briefly report -1 or a stale index while its item
+            // collection is being rebuilt.
+            let selectedIndex = min(Int(max(picker.selectedIndex, 0)), picker.options.count - 1)
+            label.text = picker.options[selectedIndex]
             label.fontSize = picker.fontSize
             label.fontWeight = picker.fontWeight
             try! label.measure(allocation)
@@ -870,7 +881,8 @@ public final class WinUIBackend:
     }
 
     public func createButton() -> Widget {
-        let button = Button()
+        let button = CustomButton()
+        button.content = button.label
         button.click.addHandler { [weak internalState] _, _ in
             guard let internalState else { return }
             internalState.buttonClickActions[ObjectIdentifier(button)]?()
@@ -884,11 +896,11 @@ public final class WinUIBackend:
         environment: EnvironmentValues,
         action: @escaping () -> Void
     ) {
-        let button = button as! WinUI.Button
-        let block = TextBlock()
-        block.text = label
-        button.content = block
-        environment.apply(to: block)
+        let button = button as! CustomButton
+        if button.label.text != label {
+            button.label.text = label
+        }
+        environment.apply(to: button.label)
         environment.apply(to: button)
         internalState.buttonClickActions[ObjectIdentifier(button)] = action
     }
@@ -916,11 +928,11 @@ public final class WinUIBackend:
         menu: Menu,
         environment: EnvironmentValues
     ) {
-        let button = button as! WinUI.Button
-        let block = TextBlock()
-        block.text = label
-        button.content = block
-        environment.apply(to: block)
+        let button = button as! CustomButton
+        if button.label.text != label {
+            button.label.text = label
+        }
+        environment.apply(to: button.label)
         environment.apply(to: button)
         button.flyout = menu
     }
@@ -1111,6 +1123,13 @@ public final class WinUIBackend:
                 let picker = CustomComboBox()
                 picker.selectionChanged.addHandler { [weak picker] _, _ in
                     guard let picker else { return }
+                    // WinUI can briefly report -1 while opening or rebuilding
+                    // the dropdown. Menu pickers do not expose a clear-selection
+                    // action, so ignore that transient state instead of writing
+                    // nil back into SwiftCrossUI and closing the dropdown.
+                    guard picker.selectedIndex >= 0 else {
+                        return
+                    }
                     picker.onChangeSelection?(Int(picker.selectedIndex))
                 }
 
@@ -1156,47 +1175,40 @@ public final class WinUIBackend:
             environment.apply(to: picker)
             picker.actualForegroundColor =
                 environment.suggestedForegroundColor.resolve(in: environment).uwpColor
-
-            // Only update options past this point, otherwise the early return
-            // will cause issues.
-            guard options.count > 0 else {
-                picker.options = []
-                return
+            let dropdownBackground = SolidColorBrush()
+            dropdownBackground.color = switch environment.colorScheme {
+                case .light:
+                    UWP.Color(a: 255, r: 255, g: 255, b: 255)
+                case .dark:
+                    UWP.Color(a: 255, r: 32, g: 32, b: 32)
             }
+            _ = picker.resources.insert("ComboBoxDropDownBackground", dropdownBackground)
 
-            if options.count == picker.items.count {
-                // for i in 0 ..< options.count {
-                // TODO: Understands how to get ComboBox items in WinUI
-                // if picker.items.getAt(UInt32(i)) as? String != options[i] {
-                // picker.items.setAt(UInt32(1), options[i])
-                // }
-                // }
-            } else if options.count > picker.items.count {
-                if !picker.items.isEmpty {
-                    for i in 0..<picker.items.count {
-                        // if picker.items.getAt(UInt32(i)) as? String != options[i] {
-                        picker.items.setAt(UInt32(i), options[i])
-                        // }
+            if picker.options != options {
+                // Keep the existing WinUI item objects where possible so
+                // selection and focus state do not churn during incremental
+                // updates. Avoid touching items when options are unchanged
+                // because rebuilding an open ComboBox closes its dropdown.
+                let sharedCount = min(picker.items.count, options.count)
+                for i in 0..<sharedCount {
+                    picker.items.setAt(UInt32(i), options[i])
+                }
+
+                if options.count > picker.items.count {
+                    for option in options[picker.items.count...] {
+                        picker.items.append(option)
+                    }
+                } else if picker.items.count > options.count {
+                    // Remove from the end so earlier indices stay valid.
+                    for i in (options.count..<picker.items.count).reversed() {
+                        picker.items.removeAt(UInt32(i))
                     }
                 }
-                for i in picker.items.count..<options.count {
-                    picker.items.append(options[i])
-                }
-            } else {
-                for i in 0..<options.count {
-                    // if picker.items.getAt(UInt32(i)) as? String != options[i] {
-                    picker.items.setAt(UInt32(i), options[i])
-                    // }
-                }
-                for i in options.count..<picker.items.count {
-                    picker.items.removeAt(UInt32(i))
-                }
+
+                picker.options = options
             }
 
-            // TODO: Proper picker updating logic
             // TODO: Picker font handling
-
-            picker.options = options
         } else if let picker = picker as? CustomRadioButtons {
             for i in 0..<min(picker.items.count, options.count) {
                 (picker.items[i] as! TextBlock).text = options[i]
@@ -1221,7 +1233,11 @@ public final class WinUIBackend:
 
     public func setSelectedOption(ofPicker picker: Widget, to selectedOption: Int?) {
         if let picker = picker as? ComboBox {
-            picker.selectedIndex = Int32(selectedOption ?? 0)
+            let selectedIndex = Int32(selectedOption ?? -1)
+            guard picker.selectedIndex != selectedIndex else {
+                return
+            }
+            picker.selectedIndex = selectedIndex
         } else if let picker = picker as? RadioButtons {
             picker.selectedIndex = Int32(selectedOption ?? -1)
         }
@@ -1234,12 +1250,17 @@ public final class WinUIBackend:
                 let internalState,
                 let textEditor
             else { return }
-            guard !textEditor.shouldBlockNextChangedSignal else {
-                textEditor.shouldBlockNextChangedSignal = false
+            let identifier = ObjectIdentifier(textEditor)
+            let text = textEditor.text
+            // WinUI may emit TextChanged for text that was already synchronized
+            // from SwiftCrossUI. Ignore it so TextEditor does not write the same
+            // value back into its Binding during commit.
+            guard internalState.textEditorContents[identifier] != text else {
                 return
             }
+            internalState.textEditorContents[identifier] = text
             // Reuse this storage because it's the same widget type as a text field
-            internalState.textFieldChangeActions[ObjectIdentifier(textEditor)]?(textEditor.text)
+            internalState.textFieldChangeActions[identifier]?(text)
         }
         textEditor.acceptsReturn = true
         textEditor.textWrapping = .wrap
@@ -1274,8 +1295,14 @@ public final class WinUIBackend:
 
     public func setContent(ofTextEditor textEditor: Widget, to content: String) {
         let textEditor = textEditor as! TextBox
-        textEditor.shouldBlockNextChangedSignal = true
+        let identifier = ObjectIdentifier(textEditor)
+        internalState.textEditorContents[identifier] = content
+        guard textEditor.text != content else {
+            return
+        }
         textEditor.text = content
+        textEditor.selectionStart = Int32(content.utf16.count)
+        textEditor.selectionLength = 0
     }
 
     public func getContent(ofTextEditor textEditor: Widget) -> String {
@@ -2354,6 +2381,10 @@ final class CustomComboBox: ComboBox {
     var options: [String] = []
     var onChangeSelection: ((Int?) -> Void)?
     var actualForegroundColor: UWP.Color = UWP.Color(a: 255, r: 0, g: 0, b: 0)
+}
+
+final class CustomButton: WinUI.Button {
+    let label = TextBlock()
 }
 
 final class CustomRadioButtons: RadioButtons {

--- a/Sources/WinUIBackend/WinUIBackend.swift
+++ b/Sources/WinUIBackend/WinUIBackend.swift
@@ -249,31 +249,7 @@ public final class WinUIBackend:
             self.dispatcherQueue = window.dispatcherQueue
         }
 
-        // import WinSDK
-        // import CWinRT
-        // @_spi(WinRTInternal) import WindowsFoundation
-        // let minSizeHook: HOOKPROC = { (nCode: Int32, wParam: WPARAM, lParam: LPARAM) in
-        //     if nCode >= 0 {
-        //         let ptr = UnsafeRawPointer(bitPattern: Int(lParam))?
-        //             .assumingMemoryBound(to: CWPRETSTRUCT.self)
-        //         if let msgInfo = ptr?.pointee, msgInfo.message == WM_GETMINMAXINFO {
-        //             print("Received WM_GETMINMAXINFO")
-
-        //             // var value: HWND = .init(0)
-        //             _ = try! window._inner.perform(
-        //                 as: __x_ABI_CMicrosoft_CUI_CXaml_CIWindowNative.self
-        //             ) { pThis in
-        //                 try! CHECKED(pThis.pointee.lpVtbl.pointee.get_WindowHandle(pThis, nil))
-        //             }
-        //         }
-        //     }
-        //     return CallNextHookEx(nil, nCode, wParam, lParam)
-        // }
-
-        // _ = SetWindowsHookExW(WH_CALLWNDPROCRET, minSizeHook, nil, GetCurrentThreadId())
-        // print("Registered")
-
-        // print(GetDpiForWindow(nil))
+        window.installSizeLimitHandler()
 
         if let size {
             setSize(ofWindow: window, to: size)
@@ -329,7 +305,8 @@ public final class WinUIBackend:
         minimum minimumSize: SIMD2<Int>,
         maximum maximumSize: SIMD2<Int>?
     ) {
-        debugLogOnce("\(#function) unimplemented")
+        window.minimumContentSize = minimumSize
+        window.maximumContentSize = maximumSize
     }
 
     public func setResizeHandler(
@@ -2394,8 +2371,12 @@ public class CustomWindow: WinUI.Window {
     var grid: WinUI.Grid
     var cachedAppWindow: WinAppSDK.AppWindow!
     var isActive = false
+    var minimumContentSize = SIMD2<Int>(0, 0)
+    var maximumContentSize: SIMD2<Int>?
+    var originalWindowProc: WNDPROC?
 
     private(set) var menuBarIsVisible = false
+    private static var windowsByHWND: [Int: CustomWindow] = [:]
 
     /// The amount of height to subtract off the window height to obtain the
     /// window's available content height.
@@ -2458,9 +2439,70 @@ public class CustomWindow: WinUI.Window {
         // Caching appWindow is apparently a good idea in terms of performance:
         // https://github.com/thebrowsercompany/swift-winrt/issues/199#issuecomment-2611006020
         cachedAppWindow = appWindow
+        installSizeLimitHandler()
 
         // Default to not showing the menu bar; we only want to show it when it's non-empty
         setMenuBarVisible(menuBarIsVisible)
+    }
+
+    func installSizeLimitHandler() {
+        guard originalWindowProc == nil else {
+            return
+        }
+
+        guard let hwnd = cachedAppWindow.getHWND() else {
+            logger.warning("failed to install WinUI size limit handler; window handle unavailable")
+            return
+        }
+
+        Self.windowsByHWND[Int(bitPattern: hwnd)] = self
+        let previous = SetWindowLongPtrW(
+            hwnd,
+            GWLP_WNDPROC,
+            LONG_PTR(bitPattern: UInt64(UInt(bitPattern: unsafeBitCast(
+                Self.windowProc,
+                to: UnsafeRawPointer.self
+            ))))
+        )
+        originalWindowProc = unsafeBitCast(previous, to: WNDPROC.self)
+    }
+
+    private static let windowProc: WNDPROC = { hwnd, message, wParam, lParam in
+        if message == WM_GETMINMAXINFO,
+           let hwnd,
+           let window = CustomWindow.windowsByHWND[Int(bitPattern: hwnd)],
+           let info = UnsafeMutableRawPointer(bitPattern: Int(lParam))?
+               .assumingMemoryBound(to: MINMAXINFO.self)
+        {
+            let scaleFactor = window.scaleFactor
+
+            info.pointee.ptMinTrackSize.x = LONG(
+                (Double(window.minimumContentSize.x) * scaleFactor).rounded(.awayFromZero)
+            )
+            info.pointee.ptMinTrackSize.y = LONG(
+                (Double(window.minimumContentSize.y + window.contentHeightAdjustment) * scaleFactor)
+                    .rounded(.awayFromZero)
+            )
+
+            if let maximumContentSize = window.maximumContentSize {
+                info.pointee.ptMaxTrackSize.x = LONG(
+                    (Double(maximumContentSize.x) * scaleFactor).rounded(.awayFromZero)
+                )
+                info.pointee.ptMaxTrackSize.y = LONG(
+                    (Double(maximumContentSize.y + window.contentHeightAdjustment) * scaleFactor)
+                        .rounded(.awayFromZero)
+                )
+            }
+        }
+
+        if let hwnd,
+           let window = CustomWindow.windowsByHWND[Int(bitPattern: hwnd)],
+           let originalWindowProc = window.originalWindowProc
+        {
+            return CallWindowProcW(originalWindowProc, hwnd, message, wParam, lParam)
+        } else {
+            return DefWindowProcW(hwnd, message, wParam, lParam)
+        }
     }
 
     /// Sets whether the menu bar of the current window is visible. The menu bar
@@ -2478,6 +2520,22 @@ public class CustomWindow: WinUI.Window {
         self.child = child
         grid.children.append(child)
         WinUI.Grid.setRow(child, 1)
+    }
+
+    deinit {
+        if let hwnd = cachedAppWindow?.getHWND() {
+            Self.windowsByHWND.removeValue(forKey: Int(bitPattern: hwnd))
+            if let originalWindowProc {
+                SetWindowLongPtrW(
+                    hwnd,
+                    GWLP_WNDPROC,
+                    LONG_PTR(bitPattern: UInt64(UInt(bitPattern: unsafeBitCast(
+                        originalWindowProc,
+                        to: UnsafeRawPointer.self
+                    ))))
+                )
+            }
+        }
     }
 }
 

--- a/Sources/WinUIBackend/WinUIBackend.swift
+++ b/Sources/WinUIBackend/WinUIBackend.swift
@@ -23,8 +23,14 @@ extension App {
 
 class WinUIApplication: SwiftApplication, @unchecked Sendable {
     static let callback = Mutex<(@MainActor (WinUIApplication) -> Void)?>(nil)
+    static let queuedURLs = Mutex<[URL]>([])
+    static let onReceiveURL = Mutex<((URL) -> Void)?>(nil)
 
     override func onLaunched(_ args: WinUI.LaunchActivatedEventArgs) {
+        if let url = Self.url(fromLaunchArguments: args.arguments) {
+            Self.receive(url)
+        }
+
         Self.callback.withLock { callback in
             // We can't explicitly hop to the main actor because we haven't set up
             // our WinUI MainActor fix yet.
@@ -32,6 +38,35 @@ class WinUIApplication: SwiftApplication, @unchecked Sendable {
                 callback?(self)
             }
         }
+    }
+
+    private static func receive(_ url: URL) {
+        if let handler = onReceiveURL.withLock({ $0 }) {
+            handler(url)
+        } else {
+            queuedURLs.withLock { urls in
+                urls.append(url)
+            }
+        }
+    }
+
+    private static func url(fromLaunchArguments arguments: String) -> URL? {
+        let trimmed = arguments.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return nil
+        }
+
+        if let url = URL(string: trimmed), url.scheme != nil {
+            return url
+        }
+
+        for argument in CommandLine.arguments.dropFirst() {
+            if let url = URL(string: argument), url.scheme != nil {
+                return url
+            }
+        }
+
+        return nil
     }
 }
 
@@ -503,8 +538,16 @@ public final class WinUIBackend:
     }
 
     public func setIncomingURLHandler(to action: @escaping (URL) -> Void) {
-        // TODO: Implement WinUIBackend setIncomingURLHandler
-        logger.warning("\(#function) not implemented")
+        WinUIApplication.queuedURLs.withLock { urls in
+            for url in urls {
+                action(url)
+            }
+            urls = []
+        }
+
+        WinUIApplication.onReceiveURL.withLock { handler in
+            handler = action
+        }
     }
 
     public func createContainer() -> Widget {

--- a/Sources/WinUIBackend/WinUIElementRepresentable.swift
+++ b/Sources/WinUIBackend/WinUIElementRepresentable.swift
@@ -143,6 +143,7 @@ extension View where Self: WinUIElementRepresentable {
         backend: Backend
     ) -> ViewLayoutResult {
         let representingWidget = widget as! RepresentingWidget<Self>
+        representingWidget.representable = self
         if let child = representingWidget.child,
            let savedSize = representingWidget.savedSize
         {

--- a/Tests/SwiftCrossUITests/OpenDialogOptionsTests.swift
+++ b/Tests/SwiftCrossUITests/OpenDialogOptionsTests.swift
@@ -1,0 +1,39 @@
+import Testing
+
+@testable import SwiftCrossUI
+
+@Suite("Testing open dialog options")
+struct OpenDialogOptionsTests {
+    @Test("Files-only dialogs use file selection mode")
+    func filesOnlySingleKindSelectionMode() {
+        let options = OpenDialogOptions(
+            allowSelectingFiles: true,
+            allowSelectingDirectories: false,
+            allowMultipleSelections: false
+        )
+
+        #expect(options.singleKindSelectionMode == .files)
+    }
+
+    @Test("Directories-only dialogs use directory selection mode")
+    func directoriesOnlySingleKindSelectionMode() {
+        let options = OpenDialogOptions(
+            allowSelectingFiles: false,
+            allowSelectingDirectories: true,
+            allowMultipleSelections: false
+        )
+
+        #expect(options.singleKindSelectionMode == .directories)
+    }
+
+    @Test("Mixed dialogs prefer file selection mode for single-kind backends")
+    func mixedSingleKindSelectionMode() {
+        let options = OpenDialogOptions(
+            allowSelectingFiles: true,
+            allowSelectingDirectories: true,
+            allowMultipleSelections: false
+        )
+
+        #expect(options.singleKindSelectionMode == .files)
+    }
+}


### PR DESCRIPTION

Refer to [https://github.com/raliclo/swift-cross-ui (develop branch)](https://github.com/raliclo/swift-cross-ui/tree/develop/testapp)

I have finished testing and issue fix for following issues with help from Claude and four test apps. 
- #493 (Fixed): WinUIBackend may crash when an environment action is called too early
- #548 (Fixed): `@AppStorage` crashes on Windows
- #523 (Fixed): Windows file open/save dialogs are slow to appear
- #659 (Fixed): Nested sheets are not supported
- #660 (Fixed): Sheets have default padding
- #449 (Fixed): Picker options do not update correctly
- #471 (Fixed): TextEditor has a thin border when unfocused
- #401 (Fixed): Full screen button is not disabled when window resizing is disabled
- #390 (Fixed): Disabled buttons do not look visibly disabled
- #190 (Fixed): Callbacks are stored in backend-wide hashmaps
- #156 (Fixed): WinUI-specific escape hatch / native API access
- #204 (Fixed): Update to latest stable WinUI / WinUI console noise
- #470 (Fixed): Regenerate WinUI bindings with latest swift-winrt

- No dedicated issue (Fixed): WinUIBackend `setSizeLimits` unimplemented log
- No dedicated issue (Fixed): WinUIBackend `setIncomingURLHandler` unimplemented log
- No dedicated issue (Fixed): WinUIBackend Implement folder selection in open dialogs for GTK, Gtk3, and WinUI backends
```
Add OpenDialogOptions.singleKindSelectionMode to express whether an open dialog should select files or directories on backends that only support one kind of item per dialog. Files are preferred when both are allowed, preserving the existing behavior of the GTK and WinUI backends.

GtkBackend/Gtk3Backend: use FileChooserAction.selectFolder instead of .open when the dialog is directories-only
WinUIBackend: split showOpenDialog into showFileOpenDialog and a new FolderPicker-based showFolderOpenDialog for directories-only dialogs; selecting multiple folders is unsupported by FolderPicker and guarded by a precondition
Add OpenDialogOptionsTests covering the selection mode logic
Also fix the Gtk3 module build on Windows:

Use gulong directly for signal handler IDs instead of converting through UInt
Rename Gtk3CHelpers' max() to static scui_max() to avoid symbol clashes
Note: Used Claude Code as LLM Coding support, I found the folder selection is not available for WinUI so I added this feature with help from Claude Code.
```