### PR TITLE
DevTools: check a minimum version for swift-format to render a nice error message

### DIFF
--- a/Scripts/format.sh
+++ b/Scripts/format.sh
@@ -2,6 +2,43 @@
 
 cd "$(dirname "$0")"/../
 
+# Minimum SwiftFormat version required by the rules enabled in .swiftformat.
+# simplifyGenericConstraints (the newest rule in --rules) was added in 0.59.0;
+# older SwiftFormat versions reject it with "Unknown rule: simplifyGenericConstraints".
+MIN_SWIFTFORMAT_VERSION="0.59.0"
+
+if ! which swiftformat &>/dev/null; then
+  echo "swiftformat not found. Install it with 'brew install swiftformat' (or see https://github.com/nicklockwood/SwiftFormat/releases)." >&2
+  exit 1
+fi
+
+installed_version="$(swiftformat --version | tr -dc '0-9.')"
+
+version_ge() {
+  # Compares dot-separated version numbers component-by-component without
+  # relying on GNU sort -V, which macOS's built-in sort does not support.
+  local IFS=.
+  local -a v1=($1)
+  local -a v2=($2)
+  local i
+  for ((i = 0; i < 3; i++)); do
+    local a="${v1[i]:-0}"
+    local b="${v2[i]:-0}"
+    if ((10#$a > 10#$b)); then
+      return 0
+    elif ((10#$a < 10#$b)); then
+      return 1
+    fi
+  done
+  return 0
+}
+
+if ! version_ge "$installed_version" "$MIN_SWIFTFORMAT_VERSION"; then
+  echo "SwiftFormat $installed_version is too old; this repo's .swiftformat rules require >= $MIN_SWIFTFORMAT_VERSION." >&2
+  echo "Upgrade with 'brew upgrade swiftformat' (or 'mint install nicklockwood/SwiftFormat'), or download a release from https://github.com/nicklockwood/SwiftFormat/releases." >&2
+  exit 1
+fi
+
 if [ -z "$1" ]; then
   swiftformat .
 else

--- a/Sources/SwiftCrossUI/ViewGraph/ViewGraphNode.swift
+++ b/Sources/SwiftCrossUI/ViewGraph/ViewGraphNode.swift
@@ -123,7 +123,7 @@ public class ViewGraphNode<NodeView: View, Backend: BaseAppBackend>: Sendable {
             #endif
 
             guard let value = fieldValue as? any ObservableProperty else {
-                return  // i.e. continue
+                return // i.e. continue
             }
 
             let cancellable = value.didChange.observeAsUIUpdater(backend: backend) { [weak self] in


### PR DESCRIPTION
## Motivation

Running `./Scripts/format.sh` with an older SwiftFormat (in my case 0.58.7) fails with:

```
Unknown rule: simplifyGenericConstraints
```

This reads like a config bug in `.swiftformat` rather than what it actually is: the installed SwiftFormat predates the `simplifyGenericConstraints` rule.
The script already has a friendly guidance message for a missing/old Java (used for the ktfmt step) but none for SwiftFormat itself.

## What changed

- Adds a `MIN_SWIFTFORMAT_VERSION="0.59.0"` floor check before invoking `swiftformat`.
- On missing binary: prints an install hint
- On too-old version: prints the installed version, the required minimum, and an upgrade path
- Version comparison (`version_ge`) is pure bash — dot-component numeric comparison — deliberately avoiding `sort -V`, which macOS's built-in `sort` does not support (no GNU coreutils dependency).

## Floor derivation

The floor is the max across every rule in `.swiftformat`'s `--rules` list, not just `simplifyGenericConstraints`. Checked each rule's "Added" changelog entry across all SwiftFormat GitHub releases

`simplifyGenericConstraints` at 0.59.0 is the newest of the set and sets the floor.

## Verification

- Happy path: ran the modified script with the updated SwiftFormat, and discovered a 1-character spacing format change. (Included)
- Failure path: simulated an old SwiftFormat by placing a fake `swiftformat` shell script earlier on `PATH` that reports `--version` as `0.58.7`.
- Missing-binary case

*I used claude to implement this PR. I reviewed every line of work, and take responsibility for any mistakes, and I'm thrilled to help collaborate with maintainers. I tested it on my system.*