### PR TITLE
Table: size to content when no height is proposed

### DIFF
--- a/Sources/AppKitBackend/AppKitBackend.swift
+++ b/Sources/AppKitBackend/AppKitBackend.swift
@@ -16,6 +16,7 @@ public final class AppKitBackend: FullAppBackend {
 
     public let defaultTableRowContentHeight = 20
     public let defaultTableCellVerticalPadding = 4
+    public let defaultTableHeaderHeight = 28
     public let defaultPaddingAmount = 10
     public let requiresToggleSwitchSpacer = false
     public let requiresImageUpdateOnScaleFactorChange = false

--- a/Sources/AppKitBackend/AppKitBackend.swift
+++ b/Sources/AppKitBackend/AppKitBackend.swift
@@ -16,8 +16,6 @@ public final class AppKitBackend: FullAppBackend {
 
     public let defaultTableRowContentHeight = 20
     public let defaultTableCellVerticalPadding = 4
-    public let defaultTableHeaderHeight = 28
-    public let defaultTableVerticalPadding = 15
     public let defaultPaddingAmount = 10
     public let requiresToggleSwitchSpacer = false
     public let requiresImageUpdateOnScaleFactorChange = false
@@ -1144,6 +1142,29 @@ public final class AppKitBackend: FullAppBackend {
         table.allowsColumnSelection = false
         scrollView.documentView = table
         return scrollView
+    }
+
+    public func tableHeaderHeight(of table: Widget) -> Int {
+        let table = (table as! NSScrollView).documentView as! NSCustomTableView
+        return Int(table.headerView?.frame.height ?? 0)
+    }
+
+    public func tableVerticalPadding(of table: Widget) -> Int {
+        let table = (table as! NSScrollView).documentView as! NSCustomTableView
+        switch table.effectiveStyle {
+            case .inset:
+                // 5 above the first row and 10 below the last.
+                return 15
+            case .sourceList:
+                return 10
+            case .fullWidth, .plain:
+                return 0
+            default:
+                // `effectiveStyle` never reports `.automatic`, so this only
+                // covers styles added in future releases. Overestimating leaves
+                // a gap; underestimating clips the last row.
+                return 15
+        }
     }
 
     public func setRowCount(ofTable table: Widget, to rowCount: Int) {

--- a/Sources/AppKitBackend/AppKitBackend.swift
+++ b/Sources/AppKitBackend/AppKitBackend.swift
@@ -17,6 +17,7 @@ public final class AppKitBackend: FullAppBackend {
     public let defaultTableRowContentHeight = 20
     public let defaultTableCellVerticalPadding = 4
     public let defaultTableHeaderHeight = 28
+    public let defaultTableVerticalPadding = 15
     public let defaultPaddingAmount = 10
     public let requiresToggleSwitchSpacer = false
     public let requiresImageUpdateOnScaleFactorChange = false

--- a/Sources/AppKitBackend/AppKitBackend.swift
+++ b/Sources/AppKitBackend/AppKitBackend.swift
@@ -1151,20 +1151,13 @@ public final class AppKitBackend: FullAppBackend {
 
     public func tableVerticalPadding(of table: Widget) -> Int {
         let table = (table as! NSScrollView).documentView as! NSCustomTableView
-        switch table.effectiveStyle {
-            case .inset:
-                // 5 above the first row and 10 below the last.
-                return 15
-            case .sourceList:
-                return 10
-            case .fullWidth, .plain:
-                return 0
-            default:
-                // `effectiveStyle` never reports `.automatic`, so this only
-                // covers styles added in future releases. Overestimating leaves
-                // a gap; underestimating clips the last row.
-                return 15
-        }
+        // `intrinsicContentSize` covers the rows plus whatever the current style
+        // insets them by, so the difference from the rows alone is the inset.
+        // It's independent of the table's assigned frame, so this doesn't
+        // depend on the height we're in the middle of computing.
+        let rowsHeight = table.customDelegate.rowHeights.reduce(0, +)
+        let padding = Int(table.intrinsicContentSize.height) - rowsHeight
+        return max(padding, 0)
     }
 
     public func setRowCount(ofTable table: Widget, to rowCount: Int) {

--- a/Sources/AppKitBackend/AppKitBackend.swift
+++ b/Sources/AppKitBackend/AppKitBackend.swift
@@ -1145,12 +1145,20 @@ public final class AppKitBackend: FullAppBackend {
     }
 
     public func tableHeaderHeight(of table: Widget) -> Int {
-        let table = (table as! NSScrollView).documentView as! NSCustomTableView
+        // `documentView` is nullable; fall back to the protocol default's
+        // no-header assumption rather than trapping.
+        guard let table = (table as? NSScrollView)?.documentView as? NSCustomTableView else {
+            return 0
+        }
         return Int(table.headerView?.frame.height ?? 0)
     }
 
     public func tableVerticalPadding(of table: Widget) -> Int {
-        let table = (table as! NSScrollView).documentView as! NSCustomTableView
+        // `documentView` is nullable; fall back to the protocol default's
+        // no-inset assumption rather than trapping.
+        guard let table = (table as? NSScrollView)?.documentView as? NSCustomTableView else {
+            return 0
+        }
         // `intrinsicContentSize` covers the rows plus whatever the current style
         // insets them by, so the difference from the rows alone is the inset.
         // It's independent of the table's assigned frame, so this doesn't

--- a/Sources/DummyBackend/DummyBackend.swift
+++ b/Sources/DummyBackend/DummyBackend.swift
@@ -253,8 +253,6 @@ public final class DummyBackend:
 
     public var defaultTableRowContentHeight = 10
     public var defaultTableCellVerticalPadding = 10
-    public var defaultTableHeaderHeight = 10
-    public var defaultTableVerticalPadding = 6
     public var defaultPaddingAmount = 10
     public var scrollBarWidth = 8
     public var requiresToggleSwitchSpacer = false

--- a/Sources/DummyBackend/DummyBackend.swift
+++ b/Sources/DummyBackend/DummyBackend.swift
@@ -253,6 +253,7 @@ public final class DummyBackend:
 
     public var defaultTableRowContentHeight = 10
     public var defaultTableCellVerticalPadding = 10
+    public var defaultTableHeaderHeight = 10
     public var defaultPaddingAmount = 10
     public var scrollBarWidth = 8
     public var requiresToggleSwitchSpacer = false

--- a/Sources/DummyBackend/DummyBackend.swift
+++ b/Sources/DummyBackend/DummyBackend.swift
@@ -254,6 +254,7 @@ public final class DummyBackend:
     public var defaultTableRowContentHeight = 10
     public var defaultTableCellVerticalPadding = 10
     public var defaultTableHeaderHeight = 10
+    public var defaultTableVerticalPadding = 6
     public var defaultPaddingAmount = 10
     public var scrollBarWidth = 8
     public var requiresToggleSwitchSpacer = false

--- a/Sources/SwiftCrossUI/Backend/BackendFeatures/Tables.swift
+++ b/Sources/SwiftCrossUI/Backend/BackendFeatures/Tables.swift
@@ -23,6 +23,16 @@ extension BackendFeatures {
         /// column header should report `0`.
         var defaultTableHeaderHeight: Int { get }
 
+        /// The vertical space a table reserves around its rows, beyond the rows
+        /// themselves and the column header.
+        ///
+        /// Some backends inset their rows within the table's body, so a table
+        /// tall enough to hold only the sum of its row heights clips its last
+        /// row. Backends that inset their rows should report the total of the
+        /// space above the first row and below the last one. Backends whose
+        /// rows meet the edges of the body should report `0`.
+        var defaultTableVerticalPadding: Int { get }
+
         /// Creates an empty table.
         ///
         /// - Returns: A table.

--- a/Sources/SwiftCrossUI/Backend/BackendFeatures/Tables.swift
+++ b/Sources/SwiftCrossUI/Backend/BackendFeatures/Tables.swift
@@ -16,6 +16,13 @@ extension BackendFeatures {
         /// backend that SwiftCrossUI won't necessarily follow in all cases.
         var defaultTableCellVerticalPadding: Int { get }
 
+        /// The height of a table's column header.
+        ///
+        /// Used when computing a table's ideal height, which is the combined
+        /// height of its rows plus its header. Backends that don't render a
+        /// column header should report `0`.
+        var defaultTableHeaderHeight: Int { get }
+
         /// Creates an empty table.
         ///
         /// - Returns: A table.

--- a/Sources/SwiftCrossUI/Backend/BackendFeatures/Tables.swift
+++ b/Sources/SwiftCrossUI/Backend/BackendFeatures/Tables.swift
@@ -19,19 +19,26 @@ extension BackendFeatures {
         /// The height of a table's column header.
         ///
         /// Used when computing a table's ideal height, which is the combined
-        /// height of its rows plus its header. Backends that don't render a
-        /// column header should report `0`.
-        var defaultTableHeaderHeight: Int { get }
+        /// height of its rows plus its header. The default implementation
+        /// assumes no column header; backends that render one should implement
+        /// this and measure it.
+        ///
+        /// - Parameter table: The table to measure the column header of.
+        /// - Returns: The height of the table's column header.
+        func tableHeaderHeight(of table: Widget) -> Int
 
         /// The vertical space a table reserves around its rows, beyond the rows
         /// themselves and the column header.
         ///
         /// Some backends inset their rows within the table's body, so a table
         /// tall enough to hold only the sum of its row heights clips its last
-        /// row. Backends that inset their rows should report the total of the
-        /// space above the first row and below the last one. Backends whose
-        /// rows meet the edges of the body should report `0`.
-        var defaultTableVerticalPadding: Int { get }
+        /// row. Backends that inset their rows should implement this and report
+        /// the total of the space above the first row and below the last one.
+        /// The default implementation assumes rows meet the edges of the body.
+        ///
+        /// - Parameter table: The table to measure the reserved space of.
+        /// - Returns: The total vertical space reserved around the table's rows.
+        func tableVerticalPadding(of table: Widget) -> Int
 
         /// Creates an empty table.
         ///
@@ -75,5 +82,21 @@ extension BackendFeatures {
             to cells: [Widget],
             withRowHeights rowHeights: [Int]
         )
+    }
+}
+
+/// The assumed column-header height when a backend doesn't measure one.
+fileprivate let defaultTableHeaderHeight = 0
+
+/// The assumed space around a table's rows when a backend doesn't measure it.
+fileprivate let defaultTableVerticalPadding = 0
+
+extension BackendFeatures.Tables {
+    public func tableHeaderHeight(of table: Widget) -> Int {
+        defaultTableHeaderHeight
+    }
+
+    public func tableVerticalPadding(of table: Widget) -> Int {
+        defaultTableVerticalPadding
     }
 }

--- a/Sources/SwiftCrossUI/Views/Table.swift
+++ b/Sources/SwiftCrossUI/Views/Table.swift
@@ -126,8 +126,14 @@ public struct Table<RowValue, RowContent: TableRowContent<RowValue>>: TypeSafeVi
         }
         children.rowHeights = rowHeights
 
+        // Along an unspecified axis the table sizes itself to its content
+        // rather than reporting zero, which would leave the body clipped away.
+        let idealHeight = rowHeights.reduce(0, +) + backend.defaultTableHeaderHeight
+
         return ViewLayoutResult(
-            size: size.replacingUnspecifiedDimensions(by: .zero),
+            size: size.replacingUnspecifiedDimensions(
+                by: ViewSize(0, Double(idealHeight))
+            ),
             childResults: cellResults
         )
     }

--- a/Sources/SwiftCrossUI/Views/Table.swift
+++ b/Sources/SwiftCrossUI/Views/Table.swift
@@ -128,7 +128,10 @@ public struct Table<RowValue, RowContent: TableRowContent<RowValue>>: TypeSafeVi
 
         // Along an unspecified axis the table sizes itself to its content
         // rather than reporting zero, which would leave the body clipped away.
-        let idealHeight = rowHeights.reduce(0, +) + backend.defaultTableHeaderHeight
+        let idealHeight =
+            rowHeights.reduce(0, +)
+                + backend.defaultTableHeaderHeight
+                + backend.defaultTableVerticalPadding
 
         return ViewLayoutResult(
             size: size.replacingUnspecifiedDimensions(

--- a/Sources/SwiftCrossUI/Views/Table.swift
+++ b/Sources/SwiftCrossUI/Views/Table.swift
@@ -44,7 +44,7 @@ public struct Table<RowValue, RowContent: TableRowContent<RowValue>>: TypeSafeVi
 
     @CastBackend<BackendFeatures.Tables>
     func computeLayout<Backend: BaseAppBackend>(
-        _: Backend.Widget,
+        _ widget: Backend.Widget,
         children: Children,
         proposedSize: ProposedViewSize,
         environment: EnvironmentValues,
@@ -130,8 +130,8 @@ public struct Table<RowValue, RowContent: TableRowContent<RowValue>>: TypeSafeVi
         // rather than reporting zero, which would leave the body clipped away.
         let idealHeight =
             rowHeights.reduce(0, +)
-                + backend.defaultTableHeaderHeight
-                + backend.defaultTableVerticalPadding
+                + backend.tableHeaderHeight(of: widget)
+                + backend.tableVerticalPadding(of: widget)
 
         return ViewLayoutResult(
             size: size.replacingUnspecifiedDimensions(

--- a/Tests/SwiftCrossUITests/TableLayoutTests.swift
+++ b/Tests/SwiftCrossUITests/TableLayoutTests.swift
@@ -1,0 +1,100 @@
+import Testing
+
+import DummyBackend
+@testable @_spi(Backends) import SwiftCrossUI
+
+@Suite("Testing for table layouts")
+struct TableLayoutTests {
+    struct Person {
+        var name: String
+        var age: Int
+    }
+
+    let backend: DummyBackend
+    let window: DummyBackend.Window
+    let environment: EnvironmentValues
+
+    let people = [
+        Person(name: "Alice", age: 99),
+        Person(name: "Bob", age: 42),
+        Person(name: "Carol", age: 7),
+    ]
+
+    @MainActor
+    init() {
+        backend = DummyBackend()
+        window = backend.createWindow(withDefaultSize: nil, id: "window")
+        environment = EnvironmentValues(backend: backend).with(\.window, window)
+    }
+
+    @MainActor
+    func table() -> some View {
+        Table(people) {
+            TableColumn("Name", value: \Person.name)
+            TableColumn("Age", value: \Person.age.description)
+        }
+    }
+
+    /// The height each row occupies given the backend's metrics: the taller of
+    /// the cell's content and the backend's default row content height, plus
+    /// padding above and below.
+    @MainActor
+    var expectedRowHeight: Int {
+        let cellHeight = Int(environment.resolvedFont.lineHeight)
+        return max(cellHeight, backend.defaultTableRowContentHeight)
+            + backend.defaultTableCellVerticalPadding * 2
+    }
+
+    @MainActor
+    @Test("Table sizes to its content when proposed no height (#692)")
+    func tableSizesToContentWithoutHeightProposal() {
+        let expectedHeight =
+            people.count * expectedRowHeight + backend.defaultTableHeaderHeight
+
+        let node = ViewGraphNode(for: table(), backend: backend, environment: environment)
+        let result = node.computeLayout(
+            proposedSize: ProposedViewSize(600, nil),
+            environment: environment
+        )
+
+        #expect(result.size.vector.y == expectedHeight)
+    }
+
+    @MainActor
+    @Test("Table accepts a proposed height")
+    func tableAcceptsProposedHeight() {
+        let node = ViewGraphNode(for: table(), backend: backend, environment: environment)
+        let result = node.computeLayout(
+            proposedSize: ProposedViewSize(600, 400),
+            environment: environment
+        )
+
+        #expect(result.size.vector.y == 400)
+    }
+
+    @MainActor
+    @Test("Table contributes its content height to a stack (#692)")
+    func tableContributesHeightToStack() {
+        let expectedTableHeight =
+            people.count * expectedRowHeight + backend.defaultTableHeaderHeight
+
+        let text = Text("Section")
+        let textNode = ViewGraphNode(for: text, backend: backend, environment: environment)
+        let textHeight = textNode.computeLayout(
+            proposedSize: ProposedViewSize(600, nil),
+            environment: environment
+        ).size.vector.y
+
+        let view = VStack(spacing: 0) {
+            text
+            table()
+        }
+        let node = ViewGraphNode(for: view, backend: backend, environment: environment)
+        let result = node.computeLayout(
+            proposedSize: ProposedViewSize(600, nil),
+            environment: environment
+        )
+
+        #expect(result.size.vector.y == textHeight + expectedTableHeight)
+    }
+}

--- a/Tests/SwiftCrossUITests/TableLayoutTests.swift
+++ b/Tests/SwiftCrossUITests/TableLayoutTests.swift
@@ -49,9 +49,10 @@ struct TableLayoutTests {
     /// its column header, and the space the backend reserves around its rows.
     @MainActor
     var expectedTableHeight: Int {
-        people.count * expectedRowHeight
-            + backend.defaultTableHeaderHeight
-            + backend.defaultTableVerticalPadding
+        let table = backend.createTable()
+        return people.count * expectedRowHeight
+            + backend.tableHeaderHeight(of: table)
+            + backend.tableVerticalPadding(of: table)
     }
 
     @MainActor

--- a/Tests/SwiftCrossUITests/TableLayoutTests.swift
+++ b/Tests/SwiftCrossUITests/TableLayoutTests.swift
@@ -45,11 +45,19 @@ struct TableLayoutTests {
             + backend.defaultTableCellVerticalPadding * 2
     }
 
+    /// The height the table occupies given the backend's metrics: its rows,
+    /// its column header, and the space the backend reserves around its rows.
+    @MainActor
+    var expectedTableHeight: Int {
+        people.count * expectedRowHeight
+            + backend.defaultTableHeaderHeight
+            + backend.defaultTableVerticalPadding
+    }
+
     @MainActor
     @Test("Table sizes to its content when proposed no height (#692)")
     func tableSizesToContentWithoutHeightProposal() {
-        let expectedHeight =
-            people.count * expectedRowHeight + backend.defaultTableHeaderHeight
+        let expectedHeight = expectedTableHeight
 
         let node = ViewGraphNode(for: table(), backend: backend, environment: environment)
         let result = node.computeLayout(
@@ -75,9 +83,6 @@ struct TableLayoutTests {
     @MainActor
     @Test("Table contributes its content height to a stack (#692)")
     func tableContributesHeightToStack() {
-        let expectedTableHeight =
-            people.count * expectedRowHeight + backend.defaultTableHeaderHeight
-
         let text = Text("Section")
         let textNode = ViewGraphNode(for: text, backend: backend, environment: environment)
         let textHeight = textNode.computeLayout(


### PR DESCRIPTION
Fixes #692. A Table proposed no height reported zero, so a table inside a content-sized container contributed no height and its body clipped away while the header still drew. 

<img width="2872" height="742" alt="Screenshot of the Feature: Before & After" src="https://github.com/user-attachments/assets/8185cade-a02e-49de-b1bb-9874b0a112eb" />

**What changed:** 
- a new `tableHeaderHeight(of:)` query on the Tables backend feature
- the sizing fix (an unspecified height substitutes content height instead of zero), 
- a new `tableVerticalPadding(of:)` query covering the space a backend reserves around its rows. Row heights were already computed for the backend; they now also feed the reported size.
- both queries are **optional** — default implementations assume no header and no row inset — so conforming to Tables requires nothing new and existing backends compile untouched.

<details><summary>Details of Measurements</summary>

**Backend values — `tableHeaderHeight(of:)`:**

- AppKitBackend: live `headerView.frame.height` on the table inside the scroll view — reads 28 on macOS, and already reads it on the first layout pass, straight out of `createTable()` before any columns or cells are set
- DummyBackend: untouched relative to main — uses the default implementation (assumes no header), exercised by the table layout tests
- Gtk / Gtk3 / UIKit / WinUI: no Tables conformance today, untouched

**Backend values — `tableVerticalPadding(of:)`:**

- AppKitBackend: live `intrinsicContentSize.height` on the table minus the row heights it was given — the remainder is whatever the current style insets the rows by. Currently reads 15 for `.inset` (5 above the first row, 10 below the last), 10 for `.sourceList`, 0 for `.fullWidth` and `.plain`; `createTable()` doesn't set a style, and AppKit resolves `.automatic` to `.inset` here. Like the header height, it already reads correctly on the first layout pass, straight out of `createTable()`
- DummyBackend: untouched relative to main — uses the default implementation (assumes no inset)
- Gtk / Gtk3 / UIKit / WinUI: no Tables conformance today, untouched

</details>

**For review:** metrics are measured live so this should be robust against OS version changes (AppKitBackend).

<details>
<summary>Headless probe (the #692 repro) before/after</summary>

Before (upstream/main @ 199a856):

```
--- proposal: width 600, height nil  (ideal-height query, i.e. inside a VStack)
    Table computeLayout reported size : SIMD2<Int>(600, 0)
    height constraint (constant/active): 0.0/true
    NSTableView numberOfRows          : 3
    sum of rect(ofRow:) heights       : 84.0

=== VStack(Text, Table, Text) with height nil
    VStack total reported size: SIMD2<Int>(600, 52)
```

After (this branch):

```
--- proposal: width 600, height nil  (ideal-height query, i.e. inside a VStack)
    Table computeLayout reported size : SIMD2<Int>(600, 127)
    height constraint (constant/active): 127.0/true
    NSTableView numberOfRows          : 3
    sum of rect(ofRow:) heights       : 84.0

--- proposal: width 600, height 400  (explicit height, i.e. fills a window)
    Table computeLayout reported size : SIMD2<Int>(600, 400)
    height constraint (constant/active): 400.0/true

=== VStack(Text, Table, Text) with height nil
    VStack total reported size: SIMD2<Int>(600, 179)
```

Heights are read from the committed height constraint — AppKitBackend applies sizes as Auto Layout constraints, so frames don't resolve in a headless harness.

</details>

*I used claude to implement this PR. I reviewed every line of work, and take responsibility for any mistakes, and I'm thrilled to help collaborate with maintainers. I wrote the PR description based on my understanding of the codebase and how the changes produce my desired results*