### PR TITLE
Exclude WinUI targets from the package graph when built by Xcode

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "55aa1eaeae7cf288b60deb7b6ff683ae7564e4152f8aa76ac19e0e7ac4ecb842",
+  "originHash" : "80215dd485167091bd6433bf4edf1c3a8433f413befaa4ebb8c969416e07055e",
   "pins" : [
     {
       "identity" : "androidkit",
@@ -170,6 +170,15 @@
       "state" : {
         "revision" : "7502b711c92a17741fa625d722b0ccbd595d8ed1",
         "version" : "1.7.2"
+      }
+    },
+    {
+      "identity" : "swift-winui",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/moreSwift/swift-winui",
+      "state" : {
+        "revision" : "df7642fbb88e23a9cc1bbd366c7d6d3780fd0251",
+        "version" : "0.2.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e1d47171a0f09d7abb802e04c331d0a0a5062a8b24a023170a5295c7a5107321",
+  "originHash" : "55aa1eaeae7cf288b60deb7b6ff683ae7564e4152f8aa76ac19e0e7ac4ecb842",
   "pins" : [
     {
       "identity" : "androidkit",
@@ -170,15 +170,6 @@
       "state" : {
         "revision" : "7502b711c92a17741fa625d722b0ccbd595d8ed1",
         "version" : "1.7.2"
-      }
-    },
-    {
-      "identity" : "swift-winui",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/moreSwift/swift-winui",
-      "state" : {
-        "revision" : "df7642fbb88e23a9cc1bbd366c7d6d3780fd0251",
-        "version" : "0.2.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -47,14 +47,10 @@ let androidBackendSupported: Bool
 
 // xcodebuild can't handle non-Apple platform conditional dependencies for some weird
 // reason, so we have to remove WinUIBackend/WinUIInterop and the swift-winui
-// dependency when we detect that we're being built by xcodebuild, mirroring
-// androidBackendSupported above.
-let winuiBackendSupported: Bool
-#if compiler(>=6.2)
-    winuiBackendSupported = !invokedByXcode
-#else
-    winuiBackendSupported = false
-#endif
+// dependency when we detect that we're being built by xcodebuild. Unlike
+// AndroidBackend there is no compiler-version floor: WinUIBackend builds with
+// every Swift version this package supports (Windows CI uses Swift 6.1).
+let winuiBackendSupported = !invokedByXcode
 
 var defaultBackendDependencies: [Target.Dependency]
 if let backend = env["SCUI_DEFAULT_BACKEND"] {
@@ -373,7 +369,7 @@ let package = Package(
     )
 #endif
 
-// Add WinUIBackend if the Swift version is new enough and we're not using xcodebuild
+// Add WinUIBackend unless we're being built by xcodebuild
 if winuiBackendSupported {
     package.dependencies += [
         .package(

--- a/Package.swift
+++ b/Package.swift
@@ -45,6 +45,16 @@ let androidBackendSupported: Bool
     androidBackendSupported = false
 #endif
 
+// swift-winui only resolves on Windows, so WinUIBackend/WinUIInterop must be excluded
+// from the package graph entirely on other hosts (resolution fails otherwise, since
+// SwiftPM resolves dependencies for every target regardless of platform conditions).
+let winuiBackendSupported: Bool
+#if os(Windows)
+    winuiBackendSupported = true
+#else
+    winuiBackendSupported = false
+#endif
+
 var defaultBackendDependencies: [Target.Dependency]
 if let backend = env["SCUI_DEFAULT_BACKEND"] {
     defaultBackendDependencies = [.target(name: backend)]
@@ -61,10 +71,15 @@ if let backend = env["SCUI_DEFAULT_BACKEND"] {
         ]
     #else
         defaultBackendDependencies = [
-            .target(name: "WinUIBackend", condition: .when(platforms: [.windows])),
             .target(name: "GtkBackend", condition: .when(platforms: [.linux])),
         ]
     #endif
+
+    if winuiBackendSupported {
+        defaultBackendDependencies += [
+            .target(name: "WinUIBackend", condition: .when(platforms: [.windows])),
+        ]
+    }
 
     if androidBackendSupported {
         defaultBackendDependencies += [
@@ -133,7 +148,6 @@ let package = Package(
         .library(name: "AppKitBackend", type: libraryType, targets: ["AppKitBackend"]),
         .library(name: "GtkBackend", type: libraryType, targets: ["GtkBackend"]),
         .library(name: "Gtk3Backend", type: libraryType, targets: ["Gtk3Backend"]),
-        .library(name: "WinUIBackend", type: libraryType, targets: ["WinUIBackend"]),
         .library(name: "DefaultBackend", type: libraryType, targets: ["DefaultBackend"]),
         .library(name: "UIKitBackend", type: libraryType, targets: ["UIKitBackend"]),
         .library(name: "Gtk", type: libraryType, targets: ["Gtk"]),
@@ -163,10 +177,6 @@ let package = Package(
         .package(
             url: "https://github.com/stackotter/swift-image-formats",
             .upToNextMinor(from: "0.5.0")
-        ),
-        .package(
-            url: "https://github.com/moreSwift/swift-winui",
-            .upToNextMinor(from: "0.2.1")
         ),
         .package(
             url: "https://github.com/stackotter/swift-benchmark",
@@ -300,23 +310,6 @@ let package = Package(
             dependencies: ["CGtk3"]
         ),
         .target(name: "UIKitBackend", dependencies: ["SwiftCrossUI"]),
-        .target(
-            name: "WinUIBackend",
-            dependencies: [
-                "SwiftCrossUI",
-                "WinUIInterop",
-                .product(name: "WinUI", package: "swift-winui"),
-                .product(name: "UWP", package: "swift-winui"),
-                .product(name: "CWinRT", package: "swift-winui"),
-                .product(name: "WinAppSDK", package: "swift-winui"),
-                .product(name: "WindowsFoundation", package: "swift-winui"),
-                .product(name: "Mutex", package: "swift-mutex"),
-            ]
-        ),
-        .target(
-            name: "WinUIInterop",
-            dependencies: []
-        ),
         .target(name: "DummyBackend", dependencies: ["SwiftCrossUI"]),
 
         .executableTarget(
@@ -378,6 +371,41 @@ let package = Package(
         )
     )
 #endif
+
+// swift-winui only resolves on Windows, so keep WinUIBackend/WinUIInterop and the
+// swift-winui dependency out of the graph on every other host.
+if winuiBackendSupported {
+    package.dependencies += [
+        .package(
+            url: "https://github.com/moreSwift/swift-winui",
+            .upToNextMinor(from: "0.2.1")
+        ),
+    ]
+
+    package.products.append(
+        .library(name: "WinUIBackend", type: libraryType, targets: ["WinUIBackend"])
+    )
+
+    package.targets += [
+        .target(
+            name: "WinUIBackend",
+            dependencies: [
+                "SwiftCrossUI",
+                "WinUIInterop",
+                .product(name: "WinUI", package: "swift-winui"),
+                .product(name: "UWP", package: "swift-winui"),
+                .product(name: "CWinRT", package: "swift-winui"),
+                .product(name: "WinAppSDK", package: "swift-winui"),
+                .product(name: "WindowsFoundation", package: "swift-winui"),
+                .product(name: "Mutex", package: "swift-mutex"),
+            ]
+        ),
+        .target(
+            name: "WinUIInterop",
+            dependencies: []
+        ),
+    ]
+}
 
 // Add AndroidBackend if the Swift version is new enough and we're not using xcodebuild
 if androidBackendSupported {

--- a/Package.swift
+++ b/Package.swift
@@ -45,12 +45,13 @@ let androidBackendSupported: Bool
     androidBackendSupported = false
 #endif
 
-// swift-winui only resolves on Windows, so WinUIBackend/WinUIInterop must be excluded
-// from the package graph entirely on other hosts (resolution fails otherwise, since
-// SwiftPM resolves dependencies for every target regardless of platform conditions).
+// xcodebuild can't handle non-Apple platform conditional dependencies for some weird
+// reason, so we have to remove WinUIBackend/WinUIInterop and the swift-winui
+// dependency when we detect that we're being built by xcodebuild, mirroring
+// androidBackendSupported above.
 let winuiBackendSupported: Bool
-#if os(Windows)
-    winuiBackendSupported = true
+#if compiler(>=6.2)
+    winuiBackendSupported = !invokedByXcode
 #else
     winuiBackendSupported = false
 #endif
@@ -372,8 +373,7 @@ let package = Package(
     )
 #endif
 
-// swift-winui only resolves on Windows, so keep WinUIBackend/WinUIInterop and the
-// swift-winui dependency out of the graph on every other host.
+// Add WinUIBackend if the Swift version is new enough and we're not using xcodebuild
 if winuiBackendSupported {
     package.dependencies += [
         .package(


### PR DESCRIPTION
Building the package under Xcode or xcodebuild on macOS dies during the build phase because WinUIInterop unconditionally includes ShObjIdl.h, a Windows-only header, and the WinUI product, targets, and swift-winui dependency are unconditional in Package.swift. This gates them behind a `winuiBackendSupported` check, keyed by `invokedByXcode`, the same shape as the existing Android block.

Options: 
a. accept this non-Windows resolution
b. drop the lockfile hunk and let each platform resolve locally
c. or prefer a different mechanism? *I need advice here*

**Verified on macOS:** on the plain SwiftPM path, `swift package dump-package` shows the full target list with both WinUI targets present (matching upstream). Under `xcodebuild`, the scheme list contains no WinUIBackend, and a full build log contains no mention of WinUIBackend, WinUIInterop, or ShObjIdl — the ShObjIdl.h failure does not occur. A fully green xcodebuild run was blocked only by missing gtk3 headers on my machine, unrelated to this change.

**Not verified:** I don't have a Windows box set up for development at this time, so I didn't try it on Windows.

*I used claude to implement this PR. I reviewed every line of work, and take responsibility for any mistakes, and I'm thrilled to help collaborate with maintainers. I wrote the PR description based on my understanding of the codebase and how the changes produce my desired results*