### PR TITLE
Android documentation updates, and various docs organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Figure 2: *Sources/YourApp/YourApp.swift*
 
 The SwiftCrossUI repository contains the above example and many more. The documentation hosts [a detailed list of all examples](https://docs.swiftcrossui.dev/documentation/swiftcrossui/examples).
 
-Running the examples requires [Swift Bundler](https://github.com/moreSwift/swift-bundler), which provides consistent behavior across platforms and enables running on iOS/tvOS devices and simulators.
+Running the examples requires [Swift Bundler](https://github.com/moreSwift/swift-bundler), which provides consistent behavior across platforms and enables running on iOS/tvOS/Android devices and simulators/emulators.
 
 To install Swift Bundler, follow [its official installation instructions](https://github.com/moreSwift/swift-bundler?tab=readme-ov-file#installation-).
 
@@ -98,9 +98,13 @@ cd swift-cross-ui/Examples
 
 # Run on host machine
 swift-bundler run CounterExample
+
 # Run on a connected device with "iPhone" in its name (macOS only)
+#   Supports Android devices as well
 swift-bundler run CounterExample --device iPhone
+
 # Run on a simulator with "iPhone 16" in its name (macOS only)
+#   Supports Android emulators as well
 swift-bundler run CounterExample --simulator "iPhone 16"
 ```
 
@@ -118,9 +122,10 @@ SwiftCrossUI has a variety of backends tailored to different operating systems. 
 > [!TIP]
 > Click through each backend name for detailed system requirements and installation instructions.
 
-- [DefaultBackend](https://docs.swiftcrossui.dev/documentation/swiftcrossui/defaultbackend): Adapts to your target operating system. On macOS it uses [AppKitBackend](https://docs.swiftcrossui.dev/documentation/swiftcrossui/appkitbackend), on Windows it uses [WinUIBackend](https://docs.swiftcrossui.dev/documentation/swiftcrossui/winuibackend), on Linux it uses [GtkBackend](https://docs.swiftcrossui.dev/documentation/swiftcrossui/gtkbackend), and on iOS and tvOS it uses [UIKitBackend](https://docs.swiftcrossui.dev/documentation/swiftcrossui/uikitbackend).
+- [DefaultBackend](https://docs.swiftcrossui.dev/documentation/swiftcrossui/defaultbackend): Adapts to your target operating system. On macOS it uses [AppKitBackend](https://docs.swiftcrossui.dev/documentation/swiftcrossui/appkitbackend), on Windows it uses [WinUIBackend](https://docs.swiftcrossui.dev/documentation/swiftcrossui/winuibackend), on Linux it uses [GtkBackend](https://docs.swiftcrossui.dev/documentation/swiftcrossui/gtkbackend), on Android it uses [AndroidBackend](https://docs.swiftcrossui.dev/documentation/swiftcrossui/androidbackend), and on iOS and tvOS it uses [UIKitBackend](https://docs.swiftcrossui.dev/documentation/swiftcrossui/uikitbackend).
 - [AppKitBackend](https://docs.swiftcrossui.dev/documentation/swiftcrossui/appkitbackend): The native macOS backend. Supports all SwiftCrossUI features.
 - [UIKitBackend](https://docs.swiftcrossui.dev/documentation/swiftcrossui/uikitbackend): The native iOS & tvOS backend. Supports most SwiftCrossUI features.
+- [AndroidBackend](https://docs.swiftcrossui.dev/documentation/swiftcrossui/androidbackend): The native Android backend. Supports most SwiftCrossUI features.
 - [WinUIBackend](https://docs.swiftcrossui.dev/documentation/swiftcrossui/winuibackend): The native Windows backend. Supports most SwiftCrossUI features.
 - [GtkBackend](https://docs.swiftcrossui.dev/documentation/swiftcrossui/gtkbackend): Works on Linux, macOS, and Windows. Requires gtk 4 to be installed. Supports most SwiftCrossUI features.
 - [Gtk3Backend](https://docs.swiftcrossui.dev/documentation/swiftcrossui/gtk3backend): Exists to target older Linux distributions. Requires gtk 3 to be installed. Supports most SwiftCrossUI features. Quite buggy on macOS due to underlying Gtk 3 bugs.

--- a/Sources/SwiftCrossUI/SwiftCrossUI.docc/Backends/Built-in backends.md
+++ b/Sources/SwiftCrossUI/SwiftCrossUI.docc/Backends/Built-in backends.md
@@ -16,6 +16,7 @@ For this reason we recommend using `DefaultBackend` unless you have particular c
 - <doc:DefaultBackend>
 - <doc:AppKitBackend>
 - <doc:UIKitBackend>
+- <doc:AndroidBackend>
 - <doc:WinUIBackend>
 - <doc:GtkBackend>
 - <doc:Gtk3Backend>

--- a/Sources/SwiftCrossUI/SwiftCrossUI.docc/Controls.md
+++ b/Sources/SwiftCrossUI/SwiftCrossUI.docc/Controls.md
@@ -19,7 +19,9 @@ Employ controls to receive user input.
 
 ### Related
 
+- ``ButtonStyle``
+- ``DatePickerStyle``
+- ``DatePickerComponents``
 - ``MenuItem``
 - ``ToggleStyle``
 - ``TextContentType``
-- ``DatePickerStyle``

--- a/Sources/SwiftCrossUI/SwiftCrossUI.docc/Gradients.md
+++ b/Sources/SwiftCrossUI/SwiftCrossUI.docc/Gradients.md
@@ -1,0 +1,13 @@
+# Gradients
+
+## Topics
+
+- ``Gradient``
+- ``LinearGradient``
+- ``RadialGradient``
+- ``AngularGradient``
+
+### Related
+
+- ``UnitPoint``
+- ``Angle``

--- a/Sources/SwiftCrossUI/SwiftCrossUI.docc/Preferences.md
+++ b/Sources/SwiftCrossUI/SwiftCrossUI.docc/Preferences.md
@@ -5,3 +5,8 @@
 - ``View/preference(key:value:)``
 - ``PreferenceValues``
 - ``ScenePreferenceValues``
+
+### Related
+
+- ``PresentationDetent``
+- ``Visibility``

--- a/Sources/SwiftCrossUI/SwiftCrossUI.docc/Shapes.md
+++ b/Sources/SwiftCrossUI/SwiftCrossUI.docc/Shapes.md
@@ -9,6 +9,7 @@
 - ``Ellipse``
 - ``Capsule``
 - ``Circle``
+- ``InsettableShape``
 
 ### Styling
 

--- a/Sources/SwiftCrossUI/SwiftCrossUI.docc/SwiftCrossUI.md
+++ b/Sources/SwiftCrossUI/SwiftCrossUI.docc/SwiftCrossUI.md
@@ -35,6 +35,7 @@ SwiftCrossUI takes inspiration from SwiftUI, allowing you to use the basic conce
 - <doc:Styling>
 - <doc:Navigation>
 - <doc:Shapes>
+- <doc:Gradients>
 - <doc:Tables>
 
 ### State

--- a/Sources/SwiftCrossUI/SwiftCrossUI.docc/The environment.md
+++ b/Sources/SwiftCrossUI/SwiftCrossUI.docc/The environment.md
@@ -60,3 +60,5 @@
 - ``LineLimit``
 - ``ScenePhase``
 - ``MenuOrder``
+- ``DeviceClass``
+- ``ScrollDismissesKeyboardMode``

--- a/Sources/SwiftCrossUI/SwiftCrossUI.docc/View fundamentals.md
+++ b/Sources/SwiftCrossUI/SwiftCrossUI.docc/View fundamentals.md
@@ -27,4 +27,6 @@ The main two view composition primitives are ``VStack``, for vertical layouts, a
 - ``ProgressView``
 - ``WebView``
 - ``GeometryReader``
+- ``GeometryProxy``
 - ``AnyView``
+- ``ContentUnavailableView``


### PR DESCRIPTION
This PR updates the README to mention Android support, updates the 'Built-in backends' article to link to the new AndroidBackend documentation article, and organizes remaining loose symbol documentation under sensible (ish) categories.