### PR TITLE
Introduce APITool and PortingKit

### DIFF
--- a/.github/workflows/build-test-and-docs.yml
+++ b/.github/workflows/build-test-and-docs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        platform: [android, linux, macos, uikit, windows]
+        platform: [android, linux, macos, uikit, windows, apitool]
         include:
           - platform: android
             paths: 'Sources/AndroidBackend/ Sources/AndroidBackendShim/'
@@ -26,6 +26,8 @@ jobs:
             paths: 'Sources/UIKitBackend/'
           - platform: windows
             paths: 'Sources/WinUIBackend/ Sources/WinUIInterop/ vcpkg.json'
+          - platform: apitool
+            paths: 'APITool/ Scripts/analyze_api.sh Scripts/generate_porting_kit.sh'
     steps:
       - uses: actions/checkout@v6
         with:
@@ -52,6 +54,7 @@ jobs:
       macos: ${{ steps.check_files.outputs.macos }}
       uikit: ${{ steps.check_files.outputs.uikit }}
       windows: ${{ steps.check_files.outputs.windows }}
+      apitool: ${{ steps.check_files.outputs.apitool }}
 
   macos:
     runs-on: macos-15
@@ -111,6 +114,27 @@ jobs:
         swift build --target MusicPlayerExample && \
         swift build --target FontsExample && \
         swift build --target TapGesturesExample
+
+  apitool:
+    runs-on: macos-15
+    needs: check_file_changes
+    if: ${{ needs.check_file_changes.outputs.apitool == 'true' }}
+    steps:
+    - name: Setup Xcode 16.4 (Swift 6.1.2)
+      uses: maxim-lobanov/setup-xcode@v1.6.0
+      with:
+        xcode-version: '16.4'
+
+    - name: Swift version
+      run: swift --version
+
+    - uses: actions/checkout@v3
+
+    - name: Run APITool analysis
+      run: ./Scripts/analyze_api.sh
+
+    - name: Run APITool stub generation
+      run: ./Scripts/generate_porting_kit.sh
 
   android:
     runs-on: macos-15

--- a/.github/workflows/build-test-and-docs.yml
+++ b/.github/workflows/build-test-and-docs.yml
@@ -78,6 +78,10 @@ jobs:
       run: swift build --target SwiftCrossUI
       working-directory: ./Examples
 
+    - name: Build _SwiftCrossUIPortingKit
+      run: swift build --target _SwiftCrossUIPortingKit
+      working-directory: ./Examples
+
     - name: Build AppKitBackend and extract symbol graphs
       uses: ./.github/actions/extract-symbol-graphs
       with:
@@ -217,6 +221,20 @@ jobs:
         export ANDROID_NDK_HOME=$PWD/android-ndk-r27d
         ./scripts/setup-android-sdk.sh
 
+    - name: Build SwiftCrossUI
+      shell: bash
+      run: |
+        cd Examples
+        /Users/runner/.swiftly/bin/swift build --target SwiftCrossUI \
+          --swift-sdk aarch64-unknown-linux-android28
+
+    - name: Build _SwiftCrossUIPortingKit
+      shell: bash
+      run: |
+        cd Examples
+        /Users/runner/.swiftly/bin/swift build --target _SwiftCrossUIPortingKit \
+          --swift-sdk aarch64-unknown-linux-android28
+
     - name: Build examples
       shell: bash
       run: |
@@ -283,6 +301,7 @@ jobs:
             }
 
             buildtarget SwiftCrossUI
+            buildtarget _SwiftCrossUIPortingKit
             buildtarget UIKitBackend
 
             cd Examples
@@ -353,6 +372,7 @@ jobs:
         }
 
         buildtarget SwiftCrossUI
+        buildtarget _SwiftCrossUIPortingKit
         buildtarget UIKitBackend
 
         cd Examples
@@ -439,6 +459,11 @@ jobs:
         PKG_CONFIG_PATH: ${{ github.workspace }}/vcpkg_installed/${{ steps.triplet.outputs.lowercase }}/lib/pkgconfig
       run: swift build --target SwiftCrossUI -v
 
+    - name: Build _SwiftCrossUIPortingKit
+      env:
+        PKG_CONFIG_PATH: ${{ github.workspace }}/vcpkg_installed/${{ steps.triplet.outputs.lowercase }}/lib/pkgconfig
+      run: swift build --target _SwiftCrossUIPortingKit
+
     - name: Build WinUIBackend and extract symbol graphs
       uses: ./.github/actions/extract-symbol-graphs
       with:
@@ -480,6 +505,10 @@ jobs:
 
     - name: Build SwiftCrossUI
       run: swift build --target SwiftCrossUI
+      working-directory: ./Examples
+
+    - name: Build _SwiftCrossUIPortingKit
+      run: swift build --target _SwiftCrossUIPortingKit
       working-directory: ./Examples
 
     - name: Build GtkBackend and extract symbol graphs

--- a/APITool/.gitignore
+++ b/APITool/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/APITool/Package.resolved
+++ b/APITool/Package.resolved
@@ -1,0 +1,33 @@
+{
+  "originHash" : "64c273cd5f8f57e787834c6a39b14f6b859cad45bf2f35c4c40e6515b3f9a0f6",
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    },
+    {
+      "identity" : "swift-macro-toolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stackotter/swift-macro-toolkit",
+      "state" : {
+        "revision" : "d6ed555bb83c9f21a292e9769952e8f52610a6e2",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/APITool/Package.swift
+++ b/APITool/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 5.10
+
+import PackageDescription
+
+let package = Package(
+    name: "APITool",
+    platforms: [.macOS(.v10_15)],
+    dependencies: [
+        .package(url: "https://github.com/swiftlang/swift-syntax", from: "603.0.0"),
+        .package(url: "https://github.com/stackotter/swift-macro-toolkit", from: "0.8.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.8.2"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "APITool",
+            dependencies: [
+                .product(name: "SwiftSyntax", package: "swift-syntax"),
+                .product(name: "SwiftParser", package: "swift-syntax"),
+                .product(name: "MacroToolkit", package: "swift-macro-toolkit"),
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ]
+        ),
+    ]
+)

--- a/APITool/README.md
+++ b/APITool/README.md
@@ -1,0 +1,34 @@
+## APITool
+
+This tool helps with the analysis and management of SwiftCrossUI's public API surface. That includes diffing SwiftCrossUI's API surface against SwiftUI's API surface, and generating the stubs that live at `../Sources/_SwiftCrossUIPortingKit/Generated` which fill in missing SwiftUI APIs with the aim of making porting from SwiftUI to SwiftCrossUI easier.
+
+### Diffing SwiftCrossUI and SwiftUI
+
+SwiftCrossUI has a convenient script at `../Scripts/analyze_api.sh` for diffing SwiftCrossUI and SwiftUI, but in case you want to do it manually, here's the command:
+
+```sh
+# Diff SwiftCrossUI and SwiftUI. If you Xcode isn't at /Applications/Xcode.app,
+#   you can specify an alternative location using --xcode-app
+swift run -c release APITool analyze --scui-checkout ..
+```
+
+### Regenerating SwiftCrossUIPortingKit's generated files
+
+SwiftCrossUI has a convenient script at `../Scripts/generate_porting_kit.sh` for regeneration the porting kit's generated files, but in case you want to do it manually, here's the command:
+
+```sh
+# Regenerate the porting kit's generated files
+swift run -c release APITool generate --scui-checkout .. \
+  ../Sources/_SwiftCrossUIPortingKit/Generated
+```
+
+### Generating SwiftCrossUI's swiftinterface file manually
+
+APITool automatically generates a swiftinterface file for SwiftCrossUI whenever one is needed, but if you want to do it manually for whatever reason, this is the command that APITool runs:
+
+```sh
+swift build --target SwiftCrossUI -Xswiftc -emit-module-interface
+```
+
+The resulting swiftinterface file will be at
+`.build/debug/SwiftCrossUI.build/SwiftCrossUI.swiftinterface`

--- a/APITool/README.md
+++ b/APITool/README.md
@@ -2,7 +2,6 @@
 
 This tool helps with the analysis and management of SwiftCrossUI's public API surface. That includes diffing SwiftCrossUI's API surface against SwiftUI's API surface, and generating the stubs that live at `../Sources/_SwiftCrossUIPortingKit/Generated` which fill in missing SwiftUI APIs with the aim of making porting from SwiftUI to SwiftCrossUI easier.
 
-
 > [!IMPORTANT]
 > APITool only supports running on a macOS host, because it requires access to the SwiftUI and SwiftUICore swiftinterface files which ship with Xcode.
 
@@ -19,13 +18,15 @@ swift run -c release APITool analyze --scui-checkout ..
 
 ### Regenerating SwiftCrossUIPortingKit's generated files
 
-SwiftCrossUI has a convenient script at `../Scripts/generate_porting_kit.sh` for regeneration the porting kit's generated files, but in case you want to do it manually, here's the command:
+SwiftCrossUI has a convenient script at `../Scripts/generate_porting_kit.sh` for regenerating the porting kit's generated files, but in case you want to do it manually, here's the command:
 
 ```sh
 # Regenerate the porting kit's generated files
 swift run -c release APITool generate --scui-checkout .. \
   ../Sources/_SwiftCrossUIPortingKit/Generated
 ```
+
+Unlike `../Scripts/generate_porting_kit.sh`, this won't format the generated files. Run `../Scripts/format.sh ../Sources/_SwiftCrossUIPortingKit/Generated` to format the generated files.
 
 ### Generating SwiftCrossUI's swiftinterface file manually
 

--- a/APITool/README.md
+++ b/APITool/README.md
@@ -2,13 +2,18 @@
 
 This tool helps with the analysis and management of SwiftCrossUI's public API surface. That includes diffing SwiftCrossUI's API surface against SwiftUI's API surface, and generating the stubs that live at `../Sources/_SwiftCrossUIPortingKit/Generated` which fill in missing SwiftUI APIs with the aim of making porting from SwiftUI to SwiftCrossUI easier.
 
+
+> [!IMPORTANT]
+> APITool only supports running on a macOS host, because it requires access to the SwiftUI and SwiftUICore swiftinterface files which ship with Xcode.
+
 ### Diffing SwiftCrossUI and SwiftUI
 
 SwiftCrossUI has a convenient script at `../Scripts/analyze_api.sh` for diffing SwiftCrossUI and SwiftUI, but in case you want to do it manually, here's the command:
 
 ```sh
-# Diff SwiftCrossUI and SwiftUI. If you Xcode isn't at /Applications/Xcode.app,
-#   you can specify an alternative location using --xcode-app
+# Diff SwiftCrossUI and SwiftUI. If you want to use a developer directory
+# different to the one reported by 'xcode-select --print-path', then you
+# specify one using the '--developer-dir' CLI option
 swift run -c release APITool analyze --scui-checkout ..
 ```
 

--- a/APITool/Sources/APITool/APITool.swift
+++ b/APITool/Sources/APITool/APITool.swift
@@ -1,0 +1,13 @@
+import ArgumentParser
+import Foundation
+
+@main
+struct APITool: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "APITool",
+        subcommands: [
+            AnalyzeCommand.self,
+            GenerateCommand.self,
+        ]
+    )
+}

--- a/APITool/Sources/APITool/Analyzer.swift
+++ b/APITool/Sources/APITool/Analyzer.swift
@@ -18,7 +18,7 @@ enum Analyzer {
     /// The analyzer collects 'interesting' declarations from the Swift interfaces
     /// that it's given. It ignores declarations that begin with an underscore
     /// (as those aren't considered properly 'public') and those that are unavailable
-    /// on iOS or macOS (as they are likely platform-specific APIs that we don't
+    /// on both iOS and macOS (as they are likely platform-specific APIs that we don't
     /// care about in SwiftCrossUI).
     static func analyze(interfaces: [SwiftInterface]) -> Result {
         let structs: [(String, Struct)] = interfaces.flatMap { interface in

--- a/APITool/Sources/APITool/Analyzer.swift
+++ b/APITool/Sources/APITool/Analyzer.swift
@@ -1,0 +1,163 @@
+import MacroToolkit
+import SwiftSyntax
+
+enum Analyzer {
+    struct Result {
+        var structs: [(module: String, decl: Struct)]
+        var structTable: [String: Int]
+        var structConformances: [String: [Type]]
+
+        var nonViewStructs: [(module: String, decl: Struct)]
+        var enums: [(module: String, decl: Enum)]
+        var extensions: [(module: String, decl: Extension)]
+
+        var views: [Struct]
+        var viewModifiers: [Function]
+    }
+
+    /// The analyzer collects 'interesting' declarations from the Swift interfaces
+    /// that it's given. It ignores declarations that begin with an underscore
+    /// (as those aren't considered properly 'public') and those that are unavailable
+    /// on iOS or macOS (as they are likely platform-specific APIs that we don't
+    /// care about in SwiftCrossUI).
+    static func analyze(interfaces: [SwiftInterface]) -> Result {
+        let structs: [(String, Struct)] = interfaces.flatMap { interface in
+            interface.structs.map { (interface.moduleName, $0) }
+        }
+        .filter { !$0.1.identifier.starts(with: "_") }
+        .filter { availableEnough($0.1._syntax.attributes) }
+        .filter { $0.1.accessLevel == .public }
+
+        let enums: [(String, Enum)] = interfaces.flatMap { interface in
+            interface.enums.map { (interface.moduleName, $0) }
+        }
+        .filter { !$0.1.identifier.starts(with: "_") }
+        .filter { availableEnough($0.1._syntax.attributes) }
+        .filter { $0.1.accessLevel == .public }
+
+        let extensions: [(String, Extension)] = interfaces.flatMap { interface in
+            interface.extensions.map { (interface.moduleName, $0) }
+        }
+        .filter { !$0.1.identifier.starts(with: "_") }
+        .filter { availableEnough($0.1._syntax.attributes) }
+
+        var structTable: [String: Int] = [:]
+        for (index, (module, structDecl)) in structs.enumerated() {
+            structTable["\(module).\(structDecl.identifier)"] = index
+        }
+
+        var conformances: [String: [Type]] = [:]
+        for (module, structDecl) in structs {
+            conformances["\(module).\(structDecl.identifier)"] = structDecl.inheritedTypes
+        }
+
+        for (_, extensionDecl) in extensions {
+            conformances[extensionDecl.identifier, default: []] += extensionDecl.inheritedTypes
+        }
+
+        // TODO: Include transitive conformances by iterating through protocols as well
+
+        var viewIdentifiers: Set<String> = []
+        var views: [Struct] = []
+        for (module, structDecl) in structs {
+            let identifier = "\(module).\(structDecl.identifier)"
+
+            guard conformances[identifier]?.contains(where: isViewProtocol(_:)) == true else {
+                continue
+            }
+
+            viewIdentifiers.insert(identifier)
+            views.append(structDecl)
+        }
+
+        var viewModifiers: [Function] = []
+        for (_, extensionDecl) in extensions {
+            guard isViewProtocol(extensionDecl.identifier) else {
+                continue
+            }
+
+            for member in extensionDecl.members {
+                guard
+                    let method = member.asFunction,
+                    !method._syntax.modifiers.contains(where: { $0.name.text == "static" }),
+                    case let .someOrAny(opaqueReturn) = method.returnType,
+                    opaqueReturn._baseSyntax.someOrAnySpecifier.text == "some",
+                    isViewProtocol(Type(opaqueReturn._baseSyntax.constraint))
+                else {
+                    continue
+                }
+
+                guard availableEnough(method._syntax.attributes) else {
+                    continue
+                }
+
+                guard !method.identifier.starts(with: "_") else {
+                    continue
+                }
+
+                viewModifiers.append(method)
+            }
+        }
+
+        let nonViewStructs = structs.filter { (module, decl) in
+            let identifier = "\(module).\(decl.identifier)"
+            return !viewIdentifiers.contains(identifier)
+        }
+
+        return Result(
+            structs: structs,
+            structTable: structTable,
+            structConformances: conformances,
+            nonViewStructs: nonViewStructs,
+            enums: enums,
+            extensions: extensions,
+            views: views,
+            viewModifiers: viewModifiers
+        )
+    }
+
+    /// A very crude check for identifying the SwiftUI View
+    /// protocol (as it spelled in the Swift interface files
+    /// that we're interested in).
+    static func isViewProtocol(_ type: Type) -> Bool {
+        isViewProtocol(type.normalizedDescription)
+    }
+
+    /// A very crude check for identifying the SwiftUI View
+    /// protocol (as it spelled in the Swift interface files
+    /// that we're interested in).
+    static func isViewProtocol(_ type: String) -> Bool {
+        ["SwiftUICore.View", "SwiftCrossUI.View"].contains(type)
+    }
+
+    /// Checks whether a set of attributes is loose enough for
+    /// us to care about the declaration that they're attached to.
+    ///
+    /// For now we just require that the declaration is available
+    /// on macOS or iOS.
+    static func availableEnough(_ attributes: AttributeListSyntax) -> Bool {
+        var unavailableOnMacOS = false
+        var unavailableOnIOS = false
+        for attribute in attributes {
+            switch attribute {
+                case .attribute(let attribute):
+                    guard
+                        attribute.attributeName.trimmedDescription == "available",
+                        let arguments = attribute.arguments?.as(AvailabilityArgumentListSyntax.self)
+                    else {
+                        continue
+                    }
+
+                    let args = arguments.map(\.argument.trimmedDescription)
+                    if args == ["macOS", "unavailable"] {
+                        unavailableOnMacOS = true
+                    } else if args == ["iOS", "unavailable"] {
+                        unavailableOnIOS = true
+                    }
+                case .ifConfigDecl:
+                    continue
+            }
+        }
+        return !unavailableOnIOS || !unavailableOnMacOS
+    }
+}

--- a/APITool/Sources/APITool/Analyzer.swift
+++ b/APITool/Sources/APITool/Analyzer.swift
@@ -80,7 +80,7 @@ enum Analyzer {
                 guard
                     let method = member.asFunction,
                     !method._syntax.modifiers.contains(where: { $0.name.text == "static" }),
-                    case let .someOrAny(opaqueReturn) = method.returnType,
+                    case .someOrAny(let opaqueReturn) = method.returnType,
                     opaqueReturn._baseSyntax.someOrAnySpecifier.text == "some",
                     isViewProtocol(Type(opaqueReturn._baseSyntax.constraint))
                 else {

--- a/APITool/Sources/APITool/Commands/AnalyzeCommand.swift
+++ b/APITool/Sources/APITool/Commands/AnalyzeCommand.swift
@@ -1,0 +1,22 @@
+import ArgumentParser
+import Foundation
+
+struct AnalyzeCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "analyze"
+    )
+
+    @OptionGroup
+    var common: CommonArguments
+
+    func run() {
+        do {
+            let context = try Context.load(common)
+            let summary = Summarizer.summarize(diff: context.diff)
+            print(summary)
+        } catch {
+            print("Error: \(error.localizedDescription)")
+            Foundation.exit(1)
+        }
+    }
+}

--- a/APITool/Sources/APITool/Commands/CommonArguments.swift
+++ b/APITool/Sources/APITool/Commands/CommonArguments.swift
@@ -1,0 +1,25 @@
+import ArgumentParser
+import Foundation
+
+struct CommonArguments: ParsableArguments {
+    @Option(
+        name: .customLong("scui-checkout"),
+        help: """
+            The location of the SwiftCrossUI checkout to operate on. Defaults \
+            to the current directory
+            """,
+        transform: { (path: String) in
+            URL(fileURLWithPath: path)
+        }
+    )
+    var swiftCrossUICheckout: URL?
+
+    @Option(
+        name: .customLong("xcode-app"),
+        help: "The location of Xcode.app. Defaults to /Applications/Xcode.app",
+        transform: { (path: String) in
+            URL(fileURLWithPath: path)
+        }
+    )
+    var xcodeApp: URL?
+}

--- a/APITool/Sources/APITool/Commands/CommonArguments.swift
+++ b/APITool/Sources/APITool/Commands/CommonArguments.swift
@@ -15,11 +15,15 @@ struct CommonArguments: ParsableArguments {
     var swiftCrossUICheckout: URL?
 
     @Option(
-        name: .customLong("xcode-app"),
-        help: "The location of Xcode.app. Defaults to /Applications/Xcode.app",
+        name: .customLong("developer-dir"),
+        help: """
+            The location of your Xcode or CLT developer dir. The default \
+            behavior is to fetch the active developer dir using \
+            'xcode-select --print-path'
+            """,
         transform: { (path: String) in
             URL(fileURLWithPath: path)
         }
     )
-    var xcodeApp: URL?
+    var developerDirectory: URL?
 }

--- a/APITool/Sources/APITool/Commands/GenerateCommand.swift
+++ b/APITool/Sources/APITool/Commands/GenerateCommand.swift
@@ -28,7 +28,7 @@ struct GenerateCommand: ParsableCommand {
 
             // Analyze SCUI and generate stubs
             let context = try Context.load(common)
-            try StubGenerator.generateStub(
+            try StubGenerator.generateStubs(
                 context: context,
                 outputDirectory: outputDirectory
             )

--- a/APITool/Sources/APITool/Commands/GenerateCommand.swift
+++ b/APITool/Sources/APITool/Commands/GenerateCommand.swift
@@ -1,0 +1,42 @@
+import ArgumentParser
+import Foundation
+
+struct GenerateCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "generate"
+    )
+
+    @OptionGroup
+    var common: CommonArguments
+
+    @Argument
+    var outputDirectory: String
+
+    func run() {
+        do {
+            // Prepare output directory
+            let outputDirectory = URL(fileURLWithPath: outputDirectory)
+            if outputDirectory.exists() {
+                try FileManager.default.removeItem(at: outputDirectory)
+            }
+            try FileManager.default.createDirectory(
+                at: outputDirectory,
+                // It's a little more likely for us to catch typos if we don't
+                // automatically create intermediate directories.
+                withIntermediateDirectories: false
+            )
+
+            // Analyze SCUI and generate stubs
+            let context = try Context.load(common)
+            try StubGenerator.generateStub(
+                context: context,
+                outputDirectory: outputDirectory
+            )
+
+            print("Done")
+        } catch {
+            print("Error: \(error.localizedDescription)")
+            Foundation.exit(1)
+        }
+    }
+}

--- a/APITool/Sources/APITool/Context.swift
+++ b/APITool/Sources/APITool/Context.swift
@@ -3,9 +3,9 @@ import Foundation
 /// General context required by all subcommands. Loads SCUI and SwiftUI, and
 /// performs analysis.
 struct Context {
-    static let swiftUICoreInterfacePath = "Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SwiftUICore.framework/Modules/SwiftUICore.swiftmodule/arm64e-apple-macos.swiftinterface"
+    static let swiftUICoreInterfacePath = "MacOSX.sdk/System/Library/Frameworks/SwiftUICore.framework/Modules/SwiftUICore.swiftmodule/arm64e-apple-macos.swiftinterface"
 
-    static let swiftUIInterfacePath = "Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SwiftUI.framework/Modules/SwiftUI.swiftmodule/arm64e-apple-macos.swiftinterface"
+    static let swiftUIInterfacePath = "MacOSX.sdk/System/Library/Frameworks/SwiftUI.framework/Modules/SwiftUI.swiftmodule/arm64e-apple-macos.swiftinterface"
 
     static let swiftCrossUIInterfacePath = ".build/debug/SwiftCrossUI.build/SwiftCrossUI.swiftinterface"
 
@@ -17,22 +17,75 @@ struct Context {
         let swiftCrossUICheckout = arguments.swiftCrossUICheckout
             ?? URL.currentDirectory
 
-        let xcodeApp: URL
-        if let location = arguments.xcodeApp {
-            xcodeApp = location
+        let developerDirectory: URL
+        if let location = arguments.developerDirectory {
+            developerDirectory = location
         } else {
-            xcodeApp = URL(fileURLWithPath: "/Applications/Xcode.app")
-            guard xcodeApp.exists() else {
+            do {
+                developerDirectory = try getDefaultDeveloperDirectory()
+            } catch {
                 throw GeneralError(
                     """
-                    Could not find Xcode at standard location (\(xcodeApp.path)). \
-                    Please specify the location to a valid Xcode installation with \
-                    the --xcode-app command line option
+                    Failed to get default developer directory using \
+                    'xcode-select --print-path'. Please provide the path to \
+                    your active developer directory manually using \
+                    '--developer-dir'. Cause: \(error.localizedDescription)
                     """
                 )
             }
         }
 
+        // If the developer directory points to a CommandLineTools installation
+        // then the SDKs that we require are at a different location.
+        let sdksDirectory: URL
+        let cltSDKsDirectory = developerDirectory / "SDKs"
+        if cltSDKsDirectory.exists() {
+            sdksDirectory = cltSDKsDirectory
+        } else {
+            sdksDirectory = developerDirectory / "Platforms/MacOSX.platform/Developer/SDKs"
+        }
+
+        // Build SwiftCrossUI to prepare the required swiftinterface file
+        let scuiInterfaceFile = try prepareSwiftCrossUISwiftInterface(
+            checkout: swiftCrossUICheckout
+        )
+
+        // Load and analyze SwiftCrossUI swiftinterface
+        let swiftCrossUI = try InterfaceLoader.loadInterface(
+            scuiInterfaceFile,
+            moduleName: "SwiftCrossUI"
+        )
+        let scuiResult = Analyzer.analyze(interfaces: [swiftCrossUI])
+
+        // Load and analyze SwiftUI & SwiftUICore swiftinterfaces (as one)
+        let swiftUICore = try InterfaceLoader.loadInterface(
+            sdksDirectory / swiftUICoreInterfacePath,
+            moduleName: "SwiftUICore"
+        )
+        let swiftUI = try InterfaceLoader.loadInterface(
+            sdksDirectory / swiftUIInterfacePath,
+            moduleName: "SwiftUI"
+        )
+        let swiftUIResult = Analyzer.analyze(interfaces: [swiftUICore, swiftUI])
+
+        // Diff the two libraries
+        let diff = Differ.diff(
+            swiftCrossUIAnalysis: scuiResult,
+            swiftUIAnalysis: swiftUIResult
+        )
+
+        return Context(
+            swiftCrossUIAnalysis: scuiResult,
+            swiftUIAnalysis: swiftUIResult,
+            diff: diff
+        )
+    }
+
+    /// Builds SwiftCrossUI with special arguments to produce the
+    /// swiftinterface file that we need for our analyses.
+    private static func prepareSwiftCrossUISwiftInterface(
+        checkout swiftCrossUICheckout: URL
+    ) throws -> URL {
         // Prepare a SwiftCrossUI swiftinterface
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
@@ -62,34 +115,29 @@ struct Context {
             )
         }
 
-        // Load and analyze SwiftCrossUI swiftinterface
-        let swiftCrossUI = try InterfaceLoader.loadInterface(
-            swiftCrossUICheckout / swiftCrossUIInterfacePath,
-            moduleName: "SwiftCrossUI"
-        )
-        let scuiResult = Analyzer.analyze(interfaces: [swiftCrossUI])
+        return swiftCrossUICheckout / swiftCrossUIInterfacePath
+    }
 
-        // Load and analyze SwiftUI & SwiftUICore swiftinterfaces (as one)
-        let swiftUICore = try InterfaceLoader.loadInterface(
-            xcodeApp / swiftUICoreInterfacePath,
-            moduleName: "SwiftUICore"
-        )
-        let swiftUI = try InterfaceLoader.loadInterface(
-            xcodeApp / swiftUIInterfacePath,
-            moduleName: "SwiftUI"
-        )
-        let swiftUIResult = Analyzer.analyze(interfaces: [swiftUICore, swiftUI])
-
-        // Diff the two libraries
-        let diff = Differ.diff(
-            swiftCrossUIAnalysis: scuiResult,
-            swiftUIAnalysis: swiftUIResult
-        )
-
-        return Context(
-            swiftCrossUIAnalysis: scuiResult,
-            swiftUIAnalysis: swiftUIResult,
-            diff: diff
-        )
+    /// Gets the user's default developer directory by running
+    /// 'xcode-select --print-path'.
+    private static func getDefaultDeveloperDirectory() throws -> URL {
+        let pipe = Pipe()
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = [
+            "xcode-select", "--print-path"
+        ]
+        process.standardOutput = pipe
+        try process.run()
+        process.waitUntilExit()
+        if process.terminationStatus != 0 {
+            throw GeneralError("non-zero exit status")
+        }
+        let pathData = pipe.fileHandleForReading.availableData
+        guard let path = String(data: pathData, encoding: .utf8) else {
+            throw GeneralError("process produced non-utf8 output")
+        }
+        let cleanedPath = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        return URL(fileURLWithPath: cleanedPath)
     }
 }

--- a/APITool/Sources/APITool/Context.swift
+++ b/APITool/Sources/APITool/Context.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// General context required by all subcommands. Loads SCUI and SwiftUI, and
+/// performs analysis.
+struct Context {
+    static let swiftUICoreInterfacePath = "Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SwiftUICore.framework/Modules/SwiftUICore.swiftmodule/arm64e-apple-macos.swiftinterface"
+
+    static let swiftUIInterfacePath = "Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SwiftUI.framework/Modules/SwiftUI.swiftmodule/arm64e-apple-macos.swiftinterface"
+
+    static let swiftCrossUIInterfacePath = ".build/debug/SwiftCrossUI.build/SwiftCrossUI.swiftinterface"
+
+    let swiftCrossUIAnalysis: Analyzer.Result
+    let swiftUIAnalysis: Analyzer.Result
+    let diff: Differ.Diff
+
+    static func load(_ arguments: CommonArguments) throws -> Context {
+        let swiftCrossUICheckout = arguments.swiftCrossUICheckout
+            ?? URL.currentDirectory
+
+        let xcodeApp: URL
+        if let location = arguments.xcodeApp {
+            xcodeApp = location
+        } else {
+            xcodeApp = URL(fileURLWithPath: "/Applications/Xcode.app")
+            guard xcodeApp.exists() else {
+                throw GeneralError(
+                    """
+                    Could not find Xcode at standard location (\(xcodeApp.path)). \
+                    Please specify the location to a valid Xcode installation with \
+                    the --xcode-app command line option
+                    """
+                )
+            }
+        }
+
+        // Prepare a SwiftCrossUI swiftinterface
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = [
+            "swift", "build",
+            "--target", "SwiftCrossUI",
+            "-Xswiftc", "-emit-module-interface"
+        ]
+        process.currentDirectoryPath = swiftCrossUICheckout.path
+        do {
+            try process.run()
+        } catch {
+            throw GeneralError(
+                """
+                Failed to build SwiftCrossUI swiftinterface: failed to launch \
+                process: \(error.localizedDescription)
+                """
+            )
+        }
+        process.waitUntilExit()
+        if process.terminationStatus != 0 {
+            throw GeneralError(
+                """
+                Failed to build SwiftCrossUI swiftinterface: non-zero exit \
+                status '\(process.terminationStatus)'
+                """
+            )
+        }
+
+        // Load and analyze SwiftCrossUI swiftinterface
+        let swiftCrossUI = try InterfaceLoader.loadInterface(
+            swiftCrossUICheckout / swiftCrossUIInterfacePath,
+            moduleName: "SwiftCrossUI"
+        )
+        let scuiResult = Analyzer.analyze(interfaces: [swiftCrossUI])
+
+        // Load and analyze SwiftUI & SwiftUICore swiftinterfaces (as one)
+        let swiftUICore = try InterfaceLoader.loadInterface(
+            xcodeApp / swiftUICoreInterfacePath,
+            moduleName: "SwiftUICore"
+        )
+        let swiftUI = try InterfaceLoader.loadInterface(
+            xcodeApp / swiftUIInterfacePath,
+            moduleName: "SwiftUI"
+        )
+        let swiftUIResult = Analyzer.analyze(interfaces: [swiftUICore, swiftUI])
+
+        // Diff the two libraries
+        let diff = Differ.diff(
+            swiftCrossUIAnalysis: scuiResult,
+            swiftUIAnalysis: swiftUIResult
+        )
+
+        return Context(
+            swiftCrossUIAnalysis: scuiResult,
+            swiftUIAnalysis: swiftUIResult,
+            diff: diff
+        )
+    }
+}

--- a/APITool/Sources/APITool/Context.swift
+++ b/APITool/Sources/APITool/Context.swift
@@ -90,9 +90,12 @@ struct Context {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
         process.arguments = [
-            "swift", "build",
-            "--target", "SwiftCrossUI",
-            "-Xswiftc", "-emit-module-interface"
+            "swift",
+            "build",
+            "--target",
+            "SwiftCrossUI",
+            "-Xswiftc",
+            "-emit-module-interface"
         ]
         process.currentDirectoryPath = swiftCrossUICheckout.path
         do {
@@ -125,7 +128,8 @@ struct Context {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
         process.arguments = [
-            "xcode-select", "--print-path"
+            "xcode-select",
+            "--print-path"
         ]
         process.standardOutput = pipe
         try process.run()

--- a/APITool/Sources/APITool/Differ.swift
+++ b/APITool/Sources/APITool/Differ.swift
@@ -78,9 +78,18 @@ enum Differ {
                 //   is wrapped in an optional, or included as a generic param etc.
                 var typeWithoutModule = parameter.type.normalizedDescription
                 typeWithoutModule = typeWithoutModule.replacingOccurrences(of: "SwiftUI.", with: "")
-                typeWithoutModule = typeWithoutModule.replacingOccurrences(of: "SwiftUICore.", with: "")
-                typeWithoutModule = typeWithoutModule.replacingOccurrences(of: "SwiftCrossUI.", with: "")
-                typeWithoutModule = typeWithoutModule.replacingOccurrences(of: "CoreFoundation.CGFloat", with: "Swift.Double")
+                typeWithoutModule = typeWithoutModule.replacingOccurrences(
+                    of: "SwiftUICore.",
+                    with: ""
+                )
+                typeWithoutModule = typeWithoutModule.replacingOccurrences(
+                    of: "SwiftCrossUI.",
+                    with: ""
+                )
+                typeWithoutModule = typeWithoutModule.replacingOccurrences(
+                    of: "CoreFoundation.CGFloat",
+                    with: "Swift.Double"
+                )
                 return Parameter(
                     label: parameter.callSiteLabel,
                     typeWithoutModule: typeWithoutModule

--- a/APITool/Sources/APITool/Differ.swift
+++ b/APITool/Sources/APITool/Differ.swift
@@ -65,8 +65,8 @@ enum Differ {
         )
     }
 
-    /// A view modifier signature used to match view modifiers
-    /// implemented by SwiftCrossUI and SwiftUI.
+    /// A view modifier signature used to match view modifiers implemented by
+    /// SwiftCrossUI and SwiftUI.
     struct ViewModifierSignature: Hashable, CustomStringConvertible, Comparable {
         init(_ function: Function) {
             identifier = function.identifier

--- a/APITool/Sources/APITool/Differ.swift
+++ b/APITool/Sources/APITool/Differ.swift
@@ -1,0 +1,115 @@
+import MacroToolkit
+
+enum Differ {
+    struct Diff {
+        /// Structs in each library that don't conform to View.
+        var nonViewStructs: Component<String>
+        /// Enums in each library.
+        var enums: Component<String>
+        /// Views in each library.
+        var views: Component<String>
+        /// View modifiers in each library (including overloads).
+        var viewModifiers: Component<ViewModifierSignature>
+        /// View modifiers in each library (excluding overloads).
+        var uniqueViewModifiers: Component<String>
+
+        struct Component<T: Comparable & Hashable> {
+            /// Elements in SwiftCrossUI.
+            var swiftCrossUI: [T]
+            /// Elements in SwiftUI.
+            var swiftUI: [T]
+            /// Elements present in both libraries.
+            var shared: [T]
+            /// Elements present in SwiftUI but missing from SwiftCrossUI.
+            var missing: [T]
+
+            init(swiftCrossUI: [T], swiftUI: [T]) {
+                self.swiftCrossUI = swiftCrossUI
+                self.swiftUI = swiftUI
+                self.shared = Array(Set(swiftCrossUI).intersection(swiftUI)).sorted()
+                self.missing = Array(Set(swiftUI).subtracting(swiftCrossUI)).sorted()
+            }
+        }
+    }
+
+    static func diff(
+        swiftCrossUIAnalysis: Analyzer.Result,
+        swiftUIAnalysis: Analyzer.Result
+    ) -> Diff {
+        let scuiModifierSignatures = swiftCrossUIAnalysis.viewModifiers
+            .map(ViewModifierSignature.init(_:))
+        let swiftUIModifierSignatures = swiftUIAnalysis.viewModifiers
+            .map(ViewModifierSignature.init(_:))
+
+        return Diff(
+            nonViewStructs: Diff.Component(
+                swiftCrossUI: swiftCrossUIAnalysis.nonViewStructs.map(\.decl.identifier),
+                swiftUI: swiftUIAnalysis.nonViewStructs.map(\.decl.identifier)
+            ),
+            enums: Diff.Component(
+                swiftCrossUI: swiftCrossUIAnalysis.enums.map(\.decl.identifier),
+                swiftUI: swiftUIAnalysis.enums.map(\.decl.identifier)
+            ),
+            views: Diff.Component(
+                swiftCrossUI: swiftCrossUIAnalysis.views.map(\.identifier),
+                swiftUI: swiftUIAnalysis.views.map(\.identifier)
+            ),
+            viewModifiers: Diff.Component(
+                swiftCrossUI: scuiModifierSignatures,
+                swiftUI: swiftUIModifierSignatures
+            ),
+            uniqueViewModifiers: Diff.Component(
+                swiftCrossUI: Array(Set(swiftCrossUIAnalysis.viewModifiers.map(\.identifier))),
+                swiftUI: Array(Set(swiftUIAnalysis.viewModifiers.map(\.identifier)))
+            )
+        )
+    }
+
+    /// A view modifier signature used to match view modifiers
+    /// implemented by SwiftCrossUI and SwiftUI.
+    struct ViewModifierSignature: Hashable, CustomStringConvertible, Comparable {
+        init(_ function: Function) {
+            identifier = function.identifier
+            parameters = function.parameters.map { parameter in
+                // FIXME: This is really janky, but it'd be a lot of effort to
+                //   do it well (relative to the amount of gain we'd get for
+                //   our usecase of analyzing known swiftinterface files).
+                //   We want to drop these module prefixes, even when the type
+                //   is wrapped in an optional, or included as a generic param etc.
+                var typeWithoutModule = parameter.type.normalizedDescription
+                typeWithoutModule = typeWithoutModule.replacingOccurrences(of: "SwiftUI.", with: "")
+                typeWithoutModule = typeWithoutModule.replacingOccurrences(of: "SwiftUICore.", with: "")
+                typeWithoutModule = typeWithoutModule.replacingOccurrences(of: "SwiftCrossUI.", with: "")
+                typeWithoutModule = typeWithoutModule.replacingOccurrences(of: "CoreFoundation.CGFloat", with: "Swift.Double")
+                return Parameter(
+                    label: parameter.callSiteLabel,
+                    typeWithoutModule: typeWithoutModule
+                )
+            }
+        }
+
+        var identifier: String
+        var parameters: [Parameter]
+
+        struct Parameter: Hashable, CustomStringConvertible {
+            var label: String?
+            var typeWithoutModule: String
+
+            var description: String {
+                "\(label ?? "_"): \(typeWithoutModule)"
+            }
+        }
+
+        var description: String {
+            "func \(identifier)(\(parameters.map(\.description).joined(separator: ", ")))"
+        }
+
+        static func < (_ lhs: Self, _ rhs: Self) -> Bool {
+            // Sort by identifier, and then sort overloads alphabetically by
+            // their textual signature representation
+            lhs.identifier < rhs.identifier || (
+                lhs.identifier == rhs.identifier && lhs.description < rhs.description
+            )
+        }
+    }
+}

--- a/APITool/Sources/APITool/Extensions.swift
+++ b/APITool/Sources/APITool/Extensions.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+extension URL {
+    static func / (_ lhs: Self, _ rhs: String) -> Self {
+        lhs.appendingPathComponent(rhs)
+    }
+
+    func exists() -> Bool {
+        FileManager.default.fileExists(atPath: path)
+    }
+
+    static var currentDirectory: URL {
+        URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+    }
+}

--- a/APITool/Sources/APITool/GeneralError.swift
+++ b/APITool/Sources/APITool/GeneralError.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// A general error.
+struct GeneralError: LocalizedError {
+    var message: String
+
+    init(_ message: String) {
+        self.message = message
+    }
+
+    var errorDescription: String? {
+        message
+    }
+}

--- a/APITool/Sources/APITool/InterfaceLoader.swift
+++ b/APITool/Sources/APITool/InterfaceLoader.swift
@@ -1,0 +1,57 @@
+import Foundation
+import SwiftSyntax
+import SwiftParser
+import MacroToolkit
+
+enum InterfaceLoader {
+    enum Error: LocalizedError {
+        case failedToReadFile(Swift.Error)
+
+        var errorDescription: String? {
+            switch self {
+                case .failedToReadFile(let error):
+                    return "Failed to read file: \(error.localizedDescription)"
+            }
+        }
+    }
+
+    static func loadInterface(_ file: URL, moduleName: String) throws(Error) -> SwiftInterface {
+        let sourceText: String
+        do {
+            sourceText = try String(contentsOf: file)
+        } catch {
+            throw Error.failedToReadFile(error)
+        }
+
+        let sourceFile = Parser.parse(source: sourceText)
+        var structs: [Struct] = []
+        var enums: [Enum] = []
+        var extensions: [Extension] = []
+        for stmt in sourceFile.statements {
+            let decl: DeclSyntax
+            switch stmt.item {
+                case .decl(let declSyntax):
+                    decl = declSyntax
+                case .expr, .stmt:
+                    continue
+            }
+
+            let wrapped = Decl(decl)
+            if let enumDecl = wrapped.asEnum {
+                enums.append(enumDecl)
+            } else if let structDecl = wrapped.asStruct {
+                structs.append(structDecl)
+            } else if let extensionDecl = wrapped._syntax.as(ExtensionDeclSyntax.self) {
+                extensions.append(Extension(extensionDecl))
+            }
+        }
+
+        return SwiftInterface(
+            moduleName: moduleName,
+            sourceFile: sourceFile,
+            structs: structs,
+            enums: enums,
+            extensions: extensions
+        )
+    }
+}

--- a/APITool/Sources/APITool/StubGenerator.swift
+++ b/APITool/Sources/APITool/StubGenerator.swift
@@ -74,7 +74,7 @@ enum StubGenerator {
             guard context.diff.enums.missing.contains(enumDecl.identifier) else {
                 continue
             }
-            
+
             // Remove non-case members (we don't handle stubbing them yet)
             var stub = enumDecl._syntax
             stub.memberBlock.members = stub.memberBlock.members.filter { member in

--- a/APITool/Sources/APITool/StubGenerator.swift
+++ b/APITool/Sources/APITool/StubGenerator.swift
@@ -110,7 +110,6 @@ enum StubGenerator {
     }
 
     private static let header = """
-        import CoreFoundation
         import Foundation
         import SwiftCrossUI
 
@@ -122,6 +121,14 @@ enum StubGenerator {
             .replacingOccurrences(of: "SwiftUI.", with: "")
             .replacingOccurrences(of: "SwiftUICore.", with: "")
             .replacingOccurrences(of: "_Concurrency.", with: "")
+            // These declarations are in Foundation on non-Apple platforms. They're
+            // also available in Foundation on Apple platforms, so we can simply
+            // rewrite all references to these types (jankily) to get things
+            // compiling on both Apple and non-Apple platforms
+            .replacingOccurrences(of: "CoreFoundation.CGRect", with: "Foundation.CGRect")
+            .replacingOccurrences(of: "CoreFoundation.CGPoint", with: "Foundation.CGPoint")
+            .replacingOccurrences(of: "CoreFoundation.CGSize", with: "Foundation.CGSize")
+            .replacingOccurrences(of: "CoreFoundation.CGFloat", with: "Foundation.CGFloat")
             .replacingOccurrences(of: "Combine.ObservableObject", with: "ObservableObject")
         try stub.write(to: file, atomically: false, encoding: .utf8)
     }

--- a/APITool/Sources/APITool/StubGenerator.swift
+++ b/APITool/Sources/APITool/StubGenerator.swift
@@ -82,6 +82,7 @@ enum StubGenerator {
             }
 
             stub.attributes = filterDeclAttributes(stub.attributes)
+            stub.modifiers.leadingTrivia = []
 
             decls.append(stub._syntaxNode)
         }
@@ -92,7 +93,7 @@ enum StubGenerator {
     private static func filterDeclAttributes(
         _ attributes: AttributeListSyntax
     ) -> AttributeListSyntax {
-        attributes.filter { attribute in
+        var attributes = attributes.filter { attribute in
             switch attribute {
                 case .attribute(let attribute):
                     let attr = attribute.attributeName.trimmedDescription
@@ -101,6 +102,11 @@ enum StubGenerator {
                     return false
             }
         }
+        if !attributes.isEmpty {
+            let index = attributes.index(before: attributes.endIndex)
+            attributes[index].trailingTrivia = [.newlines(1)]
+        }
+        return attributes
     }
 
     private static let header = """

--- a/APITool/Sources/APITool/StubGenerator.swift
+++ b/APITool/Sources/APITool/StubGenerator.swift
@@ -2,7 +2,7 @@ import Foundation
 import SwiftSyntax
 
 enum StubGenerator {
-    static func generateStub(
+    static func generateStubs(
         context: Context,
         outputDirectory: URL
     ) throws {

--- a/APITool/Sources/APITool/StubGenerator.swift
+++ b/APITool/Sources/APITool/StubGenerator.swift
@@ -1,0 +1,122 @@
+import Foundation
+import SwiftSyntax
+
+enum StubGenerator {
+    static func generateStub(
+        context: Context,
+        outputDirectory: URL
+    ) throws {
+        try generateEnumStubs(context: context, file: outputDirectory / "Enums.swift")
+    }
+
+    /// This is unused for now, because it doesn't work well enough. We need
+    /// to adopt a proper visitor-based screening and sanitisation approach.
+    /// We have to ignore structs whose signatures reference protocols that
+    /// we don't have yet (i.e. screening). And we have to remove conformances
+    /// to protocols that we either can't automatically implement or don't know
+    /// about (i.e. sanitization). Eventually we should attempt to stub out
+    /// as many members as we possibly can, but that's a future problem.
+    static func generateNonViewStructStubs(
+        context: Context,
+        file: URL
+    ) throws {
+        print("Generating non-view struct stubs (\(file.lastPathComponent))")
+
+        var decls: [Syntax] = []
+        for (_, structDecl) in context.swiftUIAnalysis.nonViewStructs {
+            guard
+                context.diff.nonViewStructs.missing.contains(structDecl.identifier)
+            else {
+                continue
+            }
+
+            var stub = structDecl._syntax
+            stub.memberBlock.members = stub.memberBlock.members.filter { member in
+                // Keep structs empty for now
+                false
+            }
+
+            stub.attributes = filterDeclAttributes(stub.attributes)
+
+            if var clause = stub.inheritanceClause {
+                // Only keep conformances that we can trivially satisfy
+                clause.inheritedTypes = clause.inheritedTypes.filter { type in
+                    [
+                        "Swift.Sendable",
+                        "Swift.Hashable",
+                        "Swift.Equatable",
+                        "Swift.Codable",
+                        "Swift.Decodable",
+                        "Swift.Encodable"
+                    ].contains(type.trimmedDescription)
+                }
+                if clause.inheritedTypes.isEmpty {
+                    stub.inheritanceClause = nil
+                } else {
+                    stub.inheritanceClause = clause
+                }
+            }
+
+            decls.append(stub._syntaxNode)
+        }
+
+        try output(decls: decls, to: file)
+    }
+
+    static func generateEnumStubs(
+        context: Context,
+        file: URL
+    ) throws {
+        print("Generating enum stubs (\(file.lastPathComponent))")
+
+        var decls: [Syntax] = []
+        for (_, enumDecl) in context.swiftUIAnalysis.enums {
+            guard context.diff.enums.missing.contains(enumDecl.identifier) else {
+                continue
+            }
+            
+            // Remove non-case members (we don't handle stubbing them yet)
+            var stub = enumDecl._syntax
+            stub.memberBlock.members = stub.memberBlock.members.filter { member in
+                member.decl.kind == .enumCaseDecl
+            }
+
+            stub.attributes = filterDeclAttributes(stub.attributes)
+
+            decls.append(stub._syntaxNode)
+        }
+
+        try output(decls: decls, to: file)
+    }
+
+    private static func filterDeclAttributes(
+        _ attributes: AttributeListSyntax
+    ) -> AttributeListSyntax {
+        attributes.filter { attribute in
+            switch attribute {
+                case .attribute(let attribute):
+                    let attr = attribute.attributeName.trimmedDescription
+                    return !["_originallyDefinedIn", "frozen", "usableFromInline"].contains(attr)
+                case .ifConfigDecl:
+                    return false
+            }
+        }
+    }
+
+    private static let header = """
+        import CoreFoundation
+        import Foundation
+        import SwiftCrossUI
+
+
+        """
+
+    private static func output(decls: [Syntax], to file: URL) throws {
+        let stub = header + decls.map(\.description).joined(separator: "\n")
+            .replacingOccurrences(of: "SwiftUI.", with: "")
+            .replacingOccurrences(of: "SwiftUICore.", with: "")
+            .replacingOccurrences(of: "_Concurrency.", with: "")
+            .replacingOccurrences(of: "Combine.ObservableObject", with: "ObservableObject")
+        try stub.write(to: file, atomically: false, encoding: .utf8)
+    }
+}

--- a/APITool/Sources/APITool/Summarizer.swift
+++ b/APITool/Sources/APITool/Summarizer.swift
@@ -1,0 +1,70 @@
+import MacroToolkit
+
+enum Summarizer {
+    struct Summary: CustomStringConvertible {
+        struct DiffComponentSummary {
+            var swiftCrossUI: Int
+            var swiftUI: Int
+            var shared: Int
+            var missing: [String]
+        }
+
+        var summaries: [(String, DiffComponentSummary)] = []
+
+        init() {}
+
+        mutating func add<T: Comparable & Hashable & CustomStringConvertible>(
+            _ name: String,
+            _ component: Differ.Diff.Component<T>
+        ) {
+            let summary = DiffComponentSummary(
+                swiftCrossUI: component.swiftCrossUI.count,
+                swiftUI: component.swiftUI.count,
+                shared: component.shared.count,
+                missing: component.missing.map(\.description)
+            )
+            summaries.append((name, summary))
+        }
+
+        func renderSection<T: CustomStringConvertible>(
+            _ name: String,
+            prefix: String,
+            value: (DiffComponentSummary) -> T
+        ) -> String {
+            var lines = ["== \(name) =="]
+            let prefix = prefix.isEmpty ? "" : prefix + " "
+            lines += summaries.map { name, summary in
+                let name = prefix.isEmpty ? name.initialUppercased : name
+                return "\(prefix)\(name): \(value(summary).description)"
+            }
+            return lines.joined(separator: "\n")
+        }
+
+        var description: String {
+            [
+                renderSection("Diff", prefix: "Missing", value: \.missing),
+                renderSection("SwiftCrossUI", prefix: "#", value: \.swiftCrossUI),
+                renderSection("SwiftUI", prefix: "#", value: \.swiftUI),
+                renderSection("Feature parity", prefix: "") { summary in
+                    Self.percentage(summary.shared, summary.swiftUI)
+                },
+            ].joined(separator: "\n\n")
+        }
+
+        static func percentage(_ count: Int, _ total: Int) -> String {
+            let fraction = Double(count) / Double(total)
+            let percent = String(format: "%.01f%%", fraction * 100)
+            return "\(percent) (\(count)/\(total))"
+        }
+    }
+
+    static func summarize(diff: Differ.Diff) -> Summary {
+        var summary = Summary()
+        summary.add("views", diff.views)
+        summary.add("view modifiers (by signature)", diff.viewModifiers)
+        summary.add("view modifiers (by name)", diff.uniqueViewModifiers)
+        summary.add("enums", diff.enums)
+        summary.add("non-view structs", diff.nonViewStructs)
+        return summary
+    }
+}

--- a/APITool/Sources/APITool/SwiftInterface.swift
+++ b/APITool/Sources/APITool/SwiftInterface.swift
@@ -1,0 +1,11 @@
+import SwiftSyntax
+import MacroToolkit
+
+struct SwiftInterface {
+    var moduleName: String
+    var sourceFile: SourceFileSyntax
+
+    var structs: [Struct]
+    var enums: [Enum]
+    var extensions: [Extension]
+}

--- a/Package.swift
+++ b/Package.swift
@@ -136,7 +136,11 @@ let package = Package(
         .library(name: "WinUIBackend", type: libraryType, targets: ["WinUIBackend"]),
         .library(name: "DefaultBackend", type: libraryType, targets: ["DefaultBackend"]),
         .library(name: "UIKitBackend", type: libraryType, targets: ["UIKitBackend"]),
-        .library(name: "_SwiftCrossUIPortingKit", type: libraryType, targets: ["_SwiftCrossUIPortingKit"]),
+        .library(
+            name: "_SwiftCrossUIPortingKit",
+            type: libraryType,
+            targets: ["_SwiftCrossUIPortingKit"]
+        ),
         .library(name: "Gtk", type: libraryType, targets: ["Gtk"]),
         .library(name: "Gtk3", type: libraryType, targets: ["Gtk3"]),
         .executable(name: "GtkExample", targets: ["GtkExample"]),

--- a/Package.swift
+++ b/Package.swift
@@ -136,6 +136,7 @@ let package = Package(
         .library(name: "WinUIBackend", type: libraryType, targets: ["WinUIBackend"]),
         .library(name: "DefaultBackend", type: libraryType, targets: ["DefaultBackend"]),
         .library(name: "UIKitBackend", type: libraryType, targets: ["UIKitBackend"]),
+        .library(name: "_SwiftCrossUIPortingKit", type: libraryType, targets: ["_SwiftCrossUIPortingKit"]),
         .library(name: "Gtk", type: libraryType, targets: ["Gtk"]),
         .library(name: "Gtk3", type: libraryType, targets: ["Gtk3"]),
         .executable(name: "GtkExample", targets: ["GtkExample"]),
@@ -217,6 +218,10 @@ let package = Package(
                 "Scenes/TupleScene.swift.gyb",
             ],
             swiftSettings: [.enableUpcomingFeature("StrictConcurrency")]
+        ),
+        .target(
+            name: "_SwiftCrossUIPortingKit",
+            dependencies: ["SwiftCrossUI"]
         ),
         .testTarget(
             name: "SwiftCrossUITests",

--- a/Scripts/analyze_api.sh
+++ b/Scripts/analyze_api.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd "$(dirname "$0")"/../APITool
+
+swift run -c release APITool analyze --scui-checkout ..

--- a/Scripts/format.sh
+++ b/Scripts/format.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+dir=$(pwd)
+
+if [ ! -z "$1" ] && [ ! -e "$1" ]; then
+  echo "Input file/dir doesn't exist"
+  exit 1
+fi
+
 cd "$(dirname "$0")"/../
 
 # Minimum SwiftFormat version required by the rules enabled in .swiftformat.
@@ -41,14 +48,20 @@ fi
 
 if [ -z "$1" ]; then
   swiftformat .
-else
-  swiftformat $1
+elif find "$dir/$1" -name "*.swift" | grep '^' &>/dev/null; then
+  swiftformat "$dir/$1"
 fi
 
 if which java &>/dev/null; then
-  ./Scripts/ensure_ktfmt.sh
-
-  java -jar Tools/ktfmt.jar --kotlinlang-style --quiet Sources/AndroidBackend/Kotlin/
+  if [ -z "$1" ]; then
+    ./Scripts/ensure_ktfmt.sh
+    echo "Running ktfmt..."
+    java -jar Tools/ktfmt.jar --kotlinlang-style --quiet Sources/AndroidBackend/Kotlin/
+  elif find "$dir/$1" -name "*.kt" | grep '^' &>/dev/null; then
+    ./Scripts/ensure_ktfmt.sh
+    echo "Running ktfmt..."
+    java -jar Tools/ktfmt.jar --kotlinlang-style --quiet "$dir/$1"
+  fi
 else
   echo 'Skipping ktfmt, as Java was not found. To format Kotlin files, install Java 17.' >&2
 fi

--- a/Scripts/generate.sh
+++ b/Scripts/generate.sh
@@ -5,3 +5,5 @@ cd "$(dirname "$0")"
 ./generate_gyb.sh
 
 ./generate_gtk.sh
+
+./generate_porting_kit.sh

--- a/Scripts/generate_porting_kit.sh
+++ b/Scripts/generate_porting_kit.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cd "$(dirname "$0")"/../APITool
+
+swift run -c release APITool generate --scui-checkout .. \
+  ../Sources/_SwiftCrossUIPortingKit/Generated

--- a/Scripts/generate_porting_kit.sh
+++ b/Scripts/generate_porting_kit.sh
@@ -4,3 +4,5 @@ cd "$(dirname "$0")"/../APITool
 
 swift run -c release APITool generate --scui-checkout .. \
   ../Sources/_SwiftCrossUIPortingKit/Generated
+
+../Scripts/format.sh ../Sources/_SwiftCrossUIPortingKit/Generated

--- a/Sources/AndroidBackend/AndroidBackend+Gradients.swift
+++ b/Sources/AndroidBackend/AndroidBackend+Gradients.swift
@@ -59,7 +59,7 @@ extension AndroidBackend: BackendFeatures.Gradients {
         in environment: EnvironmentValues
     ) {
         let tileClass = try! JavaClass<AndroidGraphics.Shader.TileMode>()
-        
+
         let stops = gradient.gradient.stops.map { Float($0.location) }
         let colors = gradient.gradient.stops.map { stop in
             stop.color.resolve(in: environment).asColorInt()

--- a/Sources/SwiftCrossUI/Environment/EnvironmentValues.swift
+++ b/Sources/SwiftCrossUI/Environment/EnvironmentValues.swift
@@ -493,7 +493,6 @@ extension EnvironmentValues {
     }
 }
 
-
 /// A key that can be used to extend the environment with new properties.
 public protocol EnvironmentKey<Value> {
     /// The type of value the key can hold.

--- a/Sources/_SwiftCrossUIPortingKit/Extensions.swift
+++ b/Sources/_SwiftCrossUIPortingKit/Extensions.swift
@@ -1,0 +1,40 @@
+import CoreFoundation
+
+extension CoreFoundation.CGRect: Swift.Equatable {
+    public static func == (_ lhs: Self, _ rhs: Self) -> Bool {
+        lhs.origin == rhs.origin && lhs.size == rhs.size
+    }
+}
+
+extension CoreFoundation.CGPoint: Swift.Equatable {
+    public static func == (_ lhs: Self, _ rhs: Self) -> Bool {
+        lhs.x == rhs.x && lhs.y == rhs.y
+    }
+}
+
+extension CoreFoundation.CGSize: Swift.Equatable {
+    public static func == (_ lhs: Self, _ rhs: Self) -> Bool {
+        lhs.width == rhs.width && lhs.height == rhs.height
+    }
+}
+
+public struct Anchor<T> {
+    public struct Source {}
+}
+
+public struct PencilSqueezeGestureValue: Equatable {}
+
+extension ControlSize {
+    public static var allCases: [ControlSize] {
+        var cases: [ControlSize] = [.mini, .small, .regular]
+
+        if #available(macOS 11.0, *) {
+            cases.append(.large)
+        }
+        if #available(iOS 17.0, macOS 14.0, tvOS 17.0, visionOS 1.0, watchOS 10.0, *) {
+            cases.append(.extraLarge)
+        }
+
+        return cases
+    }
+}

--- a/Sources/_SwiftCrossUIPortingKit/Extensions.swift
+++ b/Sources/_SwiftCrossUIPortingKit/Extensions.swift
@@ -21,6 +21,7 @@ import Foundation
     }
 #endif
 
+@available(iOS 15.0, macOS 10.15, tvOS 15.0, visionOS 1.0, watchOS 9.0, *)
 extension ControlSize {
     public static var allCases: [ControlSize] {
         var cases: [ControlSize] = [.mini, .small, .regular]

--- a/Sources/_SwiftCrossUIPortingKit/Extensions.swift
+++ b/Sources/_SwiftCrossUIPortingKit/Extensions.swift
@@ -1,22 +1,25 @@
-import CoreFoundation
+import Foundation
 
-extension CoreFoundation.CGRect: Swift.Equatable {
-    public static func == (_ lhs: Self, _ rhs: Self) -> Bool {
-        lhs.origin == rhs.origin && lhs.size == rhs.size
+// These types are already Equatable on non-Apple platforms
+#if canImport(Darwin)
+    extension Foundation.CGRect: Swift.Equatable {
+        public static func == (_ lhs: Self, _ rhs: Self) -> Bool {
+            lhs.origin == rhs.origin && lhs.size == rhs.size
+        }
     }
-}
 
-extension CoreFoundation.CGPoint: Swift.Equatable {
-    public static func == (_ lhs: Self, _ rhs: Self) -> Bool {
-        lhs.x == rhs.x && lhs.y == rhs.y
+    extension Foundation.CGPoint: Swift.Equatable {
+        public static func == (_ lhs: Self, _ rhs: Self) -> Bool {
+            lhs.x == rhs.x && lhs.y == rhs.y
+        }
     }
-}
 
-extension CoreFoundation.CGSize: Swift.Equatable {
-    public static func == (_ lhs: Self, _ rhs: Self) -> Bool {
-        lhs.width == rhs.width && lhs.height == rhs.height
+    extension Foundation.CGSize: Swift.Equatable {
+        public static func == (_ lhs: Self, _ rhs: Self) -> Bool {
+            lhs.width == rhs.width && lhs.height == rhs.height
+        }
     }
-}
+#endif
 
 extension ControlSize {
     public static var allCases: [ControlSize] {

--- a/Sources/_SwiftCrossUIPortingKit/Extensions.swift
+++ b/Sources/_SwiftCrossUIPortingKit/Extensions.swift
@@ -18,12 +18,6 @@ extension CoreFoundation.CGSize: Swift.Equatable {
     }
 }
 
-public struct Anchor<T> {
-    public struct Source {}
-}
-
-public struct PencilSqueezeGestureValue: Equatable {}
-
 extension ControlSize {
     public static var allCases: [ControlSize] {
         var cases: [ControlSize] = [.mini, .small, .regular]

--- a/Sources/_SwiftCrossUIPortingKit/Generated/Enums.swift
+++ b/Sources/_SwiftCrossUIPortingKit/Generated/Enums.swift
@@ -1,4 +1,3 @@
-import CoreFoundation
 import Foundation
 import SwiftCrossUI
 
@@ -293,7 +292,7 @@ public enum TouchBarItemPresence : Swift.Sendable {
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
 @available(watchOS, unavailable)
 public enum HoverPhase : Swift.Equatable {
-    case active(CoreFoundation.CGPoint)
+    case active(Foundation.CGPoint)
     case ended
 }
 
@@ -360,7 +359,7 @@ public enum PreviewPlatform : Swift.Sendable {
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public enum PopoverAttachmentAnchor {
-    case rect(Anchor<CoreFoundation.CGRect>.Source)
+    case rect(Anchor<Foundation.CGRect>.Source)
     case point(UnitPoint)
 }
 

--- a/Sources/_SwiftCrossUIPortingKit/Generated/Enums.swift
+++ b/Sources/_SwiftCrossUIPortingKit/Generated/Enums.swift
@@ -8,14 +8,8 @@ public enum LayoutDirection : Swift.Hashable, Swift.CaseIterable, Swift.Sendable
     case rightToLeft
 }
 
-@available(
-    iOS 18.0,
-    macOS 15.0,
-    tvOS 18.0,
-    watchOS 11.0,
-    visionOS 2.0,
-    *
-)public enum ScrollPhase : Swift.Equatable {
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+public enum ScrollPhase : Swift.Equatable {
     case idle
     case tracking
     case interacting
@@ -23,40 +17,26 @@ public enum LayoutDirection : Swift.Hashable, Swift.CaseIterable, Swift.Sendable
     case animating
 }
 
-@available(
-    iOS 18.0,
-    macOS 15.0,
-    tvOS 18.0,
-    watchOS 11.0,
-    visionOS 2.0,
-    *
-)public enum HorizontalDirection : Swift.Int8, Swift.CaseIterable, Swift.Codable {
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+public enum HorizontalDirection : Swift.Int8, Swift.CaseIterable, Swift.Codable {
     case leading
     case trailing
 }
 
-@available(
-    iOS 18.0,
-    macOS 15.0,
-    tvOS 18.0,
-    watchOS 11.0,
-    visionOS 2.0,
-    *
-)public enum VerticalDirection : Swift.Int8, Swift.CaseIterable, Swift.Codable {
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+public enum VerticalDirection : Swift.Int8, Swift.CaseIterable, Swift.Codable {
     case up
     case down
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)public enum HorizontalEdge : Swift.Int8,
-    Swift.CaseIterable, Swift.Codable
-{
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public enum HorizontalEdge : Swift.Int8, Swift.CaseIterable, Swift.Codable {
     case leading
     case trailing
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)public enum VerticalEdge : Swift.Int8,
-    Swift.CaseIterable, Swift.Codable
-{
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public enum VerticalEdge : Swift.Int8, Swift.CaseIterable, Swift.Codable {
     case top
     case bottom
 }
@@ -89,13 +69,8 @@ public enum ColorRenderingMode : Swift.Sendable {
     case extendedLinear
 }
 
-@available(
-    iOS 15.0,
-    macOS 12.0,
-    tvOS 15.0,
-    watchOS 8.0,
-    *
-)public enum AccessibilityHeadingLevel : Swift.UInt {
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public enum AccessibilityHeadingLevel : Swift.UInt {
     case unspecified
     case h1
     case h2
@@ -201,12 +176,14 @@ public enum Prominence : Swift.Sendable {
 @available(macOS 26.0, visionOS 2.0, *)
 @available(iOS, unavailable)
 @available(watchOS, unavailable)
-@available(tvOS, unavailable)public enum Chirality : Swift.Hashable, Swift.Sendable {
+@available(tvOS, unavailable)
+public enum Chirality : Swift.Hashable, Swift.Sendable {
     case left
     case right
 }
 
-@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)public enum TransitionPhase {
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+public enum TransitionPhase {
     case willAppear
     case identity
     case didDisappear
@@ -219,9 +196,8 @@ public enum CoordinateSpace {
     case named(Swift.AnyHashable)
 }
 
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)public enum TextAlignment : Swift
-    .Hashable, Swift.CaseIterable
-{
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+public enum TextAlignment : Swift.Hashable, Swift.CaseIterable {
     case leading
     case center
     case trailing
@@ -273,13 +249,8 @@ public enum RoundedCornerStyle : Swift.Sendable {
     case continuous
 }
 
-@available(
-    iOS 14.0,
-    macOS 11.0,
-    tvOS 14.0,
-    watchOS 7.0,
-    *
-)public enum AccessibilityLabeledPairRole {
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
+public enum AccessibilityLabeledPairRole {
     case label
     case content
 }
@@ -320,7 +291,8 @@ public enum TouchBarItemPresence : Swift.Sendable {
 }
 
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
-@available(watchOS, unavailable)public enum HoverPhase : Swift.Equatable {
+@available(watchOS, unavailable)
+public enum HoverPhase : Swift.Equatable {
     case active(CoreFoundation.CGPoint)
     case ended
 }
@@ -338,7 +310,8 @@ public enum ScenePhase : Swift.Comparable {
     case active
 }
 
-@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)public enum ScrollTransitionPhase {
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+public enum ScrollTransitionPhase {
     case topLeading
     case identity
     case bottomTrailing
@@ -348,7 +321,8 @@ public enum ScenePhase : Swift.Comparable {
 @available(iOS, unavailable)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-@available(visionOS, unavailable)public enum FrameResizePosition : Swift.Int8, Swift.CaseIterable {
+@available(visionOS, unavailable)
+public enum FrameResizePosition : Swift.Int8, Swift.CaseIterable {
     case top
     case leading
     case bottom
@@ -363,7 +337,8 @@ public enum ScenePhase : Swift.Comparable {
 @available(iOS, unavailable)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-@available(visionOS, unavailable)public enum FrameResizeDirection : Swift.Int8, Swift.CaseIterable {
+@available(visionOS, unavailable)
+public enum FrameResizeDirection : Swift.Int8, Swift.CaseIterable {
     case inward
     case outward
 }
@@ -402,7 +377,8 @@ public enum MoveCommandDirection : Swift.Sendable {
 
 @available(iOS 17.5, macOS 14.5, visionOS 26.2, *)
 @available(watchOS, unavailable)
-@available(tvOS, unavailable)public enum PencilSqueezeGesturePhase : Swift.Equatable {
+@available(tvOS, unavailable)
+public enum PencilSqueezeGesturePhase : Swift.Equatable {
     case active(PencilSqueezeGestureValue)
     case ended(PencilSqueezeGestureValue)
     case failed

--- a/Sources/_SwiftCrossUIPortingKit/Generated/Enums.swift
+++ b/Sources/_SwiftCrossUIPortingKit/Generated/Enums.swift
@@ -1,0 +1,384 @@
+import CoreFoundation
+import Foundation
+import SwiftCrossUI
+
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+public enum LayoutDirection : Swift.Hashable, Swift.CaseIterable, Swift.Sendable {
+  case leftToRight
+  case rightToLeft
+}
+
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)public enum ScrollPhase : Swift.Equatable {
+  case idle
+  case tracking
+  case interacting
+  case decelerating
+  case animating
+}
+
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)public enum HorizontalDirection : Swift.Int8, Swift.CaseIterable, Swift.Codable {
+  case leading
+  case trailing
+}
+
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)public enum VerticalDirection : Swift.Int8, Swift.CaseIterable, Swift.Codable {
+  case up
+  case down
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)public enum HorizontalEdge : Swift.Int8, Swift.CaseIterable, Swift.Codable {
+  case leading
+  case trailing
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)public enum VerticalEdge : Swift.Int8, Swift.CaseIterable, Swift.Codable {
+  case top
+  case bottom
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public enum TimelineScheduleMode : Swift.Sendable {
+  case normal
+  case lowFrequency
+}
+
+@available(macOS 26.0, visionOS 26.0, *)
+@available(iOS, unavailable)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
+public enum WorldRecenterPhase : Swift.Sendable {
+  case began
+  case ended
+}
+
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+public enum LayoutDirectionBehavior : Swift.Hashable, Swift.Sendable {
+  case fixed
+  case mirrors(in: LayoutDirection)
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+public enum ColorRenderingMode : Swift.Sendable {
+  case nonLinear
+  case linear
+  case extendedLinear
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)public enum AccessibilityHeadingLevel : Swift.UInt {
+  case unspecified
+  case h1
+  case h2
+  case h3
+  case h4
+  case h5
+  case h6
+}
+
+@available(iOS 15.0, macOS 10.15, tvOS 15.0, visionOS 1.0, watchOS 9.0, *)
+public enum ControlSize : Swift.CaseIterable, Swift.Sendable {
+  case mini
+  case small
+  case regular
+  @available(macOS 11.0, *)
+  case large
+  @available(iOS 17.0, macOS 14.0, tvOS 17.0, visionOS 1.0, watchOS 10.0, *)
+  case extraLarge
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+public enum BlendMode : Swift.Sendable {
+  case normal
+  case multiply
+  case screen
+  case overlay
+  case darken
+  case lighten
+  case colorDodge
+  case colorBurn
+  case softLight
+  case hardLight
+  case difference
+  case exclusion
+  case hue
+  case saturation
+  case color
+  case luminosity
+  case sourceAtop
+  case destinationOver
+  case destinationOut
+  case plusDarker
+  case plusLighter
+}
+
+@available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, visionOS 26.0, *)
+public enum AttributedTextFormatting {
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public enum ShapeRole : Swift.Sendable {
+  case fill
+  case stroke
+  case separator
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public enum DynamicTypeSize : Swift.Hashable, Swift.Comparable, Swift.CaseIterable, Swift.Sendable {
+  case xSmall
+  case small
+  case medium
+  case large
+  case xLarge
+  case xxLarge
+  case xxxLarge
+  case accessibility1
+  case accessibility2
+  case accessibility3
+  case accessibility4
+  case accessibility5
+}
+
+@available(iOS, introduced: 13.0, deprecated: 100000.0, renamed: "DynamicTypeSize")
+@available(macOS, introduced: 10.15, deprecated: 100000.0, renamed: "DynamicTypeSize")
+@available(tvOS, introduced: 13.0, deprecated: 100000.0, renamed: "DynamicTypeSize")
+@available(watchOS, introduced: 6.0, deprecated: 100000.0, renamed: "DynamicTypeSize")
+@available(visionOS, introduced: 1.0, deprecated: 100000.0, renamed: "DynamicTypeSize")
+public enum ContentSizeCategory : Swift.Hashable, Swift.CaseIterable, Swift.Sendable {
+  case extraSmall
+  case small
+  case medium
+  case large
+  case extraLarge
+  case extraExtraLarge
+  case extraExtraExtraLarge
+  case accessibilityMedium
+  case accessibilityLarge
+  case accessibilityExtraLarge
+  case accessibilityExtraExtraLarge
+  case accessibilityExtraExtraExtraLarge
+}
+
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+public enum SystemFormatStyle : Swift.Sendable {
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public enum Prominence : Swift.Sendable {
+  case standard
+  case increased
+}
+
+@available(macOS 26.0, visionOS 2.0, *)
+@available(iOS, unavailable)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)public enum Chirality : Swift.Hashable, Swift.Sendable {
+  case left
+  case right
+}
+
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)public enum TransitionPhase {
+  case willAppear
+  case identity
+  case didDisappear
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+public enum CoordinateSpace {
+  case global
+  case local
+  case named(Swift.AnyHashable)
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)public enum TextAlignment : Swift.Hashable, Swift.CaseIterable {
+  case leading
+  case center
+  case trailing
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+public enum UserInterfaceSizeClass : Swift.Sendable {
+  case compact
+  case regular
+}
+
+@available(iOS, unavailable)
+@available(macCatalyst, introduced: 13.0, deprecated: 100000.0, message: "Use `EnvironmentValues.appearsActive` instead.")
+@available(macOS, introduced: 10.15, deprecated: 100000.0, message: "Use `EnvironmentValues.appearsActive` instead.")
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+@available(visionOS, unavailable)
+public enum ControlActiveState : Swift.Equatable, Swift.CaseIterable, Swift.Sendable {
+  case key
+  case active
+  case inactive
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+public enum LegibilityWeight : Swift.Hashable, Swift.Sendable {
+  case regular
+  case bold
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+public enum ColorSchemeContrast : Swift.CaseIterable, Swift.Sendable {
+  case standard
+  case increased
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+public enum RoundedCornerStyle : Swift.Sendable {
+  case circular
+  case continuous
+}
+
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)public enum AccessibilityLabeledPairRole {
+  case label
+  case content
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+public enum AccessibilityAdjustmentDirection : Swift.Sendable {
+  case increment
+  case decrement
+}
+
+@available(iOS 13.4, macOS 10.15, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+public enum DropOperation : Swift.Sendable {
+  case cancel
+  case forbidden
+  case copy
+  case move
+  @available(macOS 26.0, *)
+  @available(iOS, unavailable)
+  @available(visionOS, unavailable)
+  case delete
+  @available(macOS 26.0, *)
+  @available(iOS, unavailable)
+  @available(visionOS, unavailable)
+  case alias
+}
+
+@available(macOS 10.15, *)
+@available(iOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+@available(visionOS, unavailable)
+public enum TouchBarItemPresence : Swift.Sendable {
+  case required(_: Swift.String)
+  case `default`(_: Swift.String)
+  case optional(_: Swift.String)
+}
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(watchOS, unavailable)public enum HoverPhase : Swift.Equatable {
+  case active(CoreFoundation.CGPoint)
+  case ended
+}
+
+@available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, visionOS 26.0, *)
+public enum TabViewBottomAccessoryPlacement : Swift.Hashable, Swift.Sendable {
+  case inline
+  case expanded
+}
+
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
+public enum ScenePhase : Swift.Comparable {
+  case background
+  case inactive
+  case active
+}
+
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)public enum ScrollTransitionPhase {
+  case topLeading
+  case identity
+  case bottomTrailing
+}
+
+@available(macOS 15.0, *)
+@available(iOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+@available(visionOS, unavailable)public enum FrameResizePosition : Swift.Int8, Swift.CaseIterable {
+  case top
+  case leading
+  case bottom
+  case trailing
+  case topLeading
+  case topTrailing
+  case bottomLeading
+  case bottomTrailing
+}
+
+@available(macOS 15.0, *)
+@available(iOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+@available(visionOS, unavailable)public enum FrameResizeDirection : Swift.Int8, Swift.CaseIterable {
+  case inward
+  case outward
+}
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+public enum SidebarRowSize : Swift.Sendable {
+  case small
+  case medium
+  case large
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+public enum PreviewPlatform : Swift.Sendable {
+  case iOS
+  case macOS
+  case tvOS
+  case watchOS
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+public enum PopoverAttachmentAnchor {
+  case rect(Anchor<CoreFoundation.CGRect>.Source)
+  case point(UnitPoint)
+}
+
+@available(macOS 10.15, tvOS 13.0, *)
+@available(iOS, unavailable)
+@available(watchOS, unavailable)
+@available(visionOS, unavailable)
+public enum MoveCommandDirection : Swift.Sendable {
+  case up
+  case down
+  case left
+  case right
+}
+
+@available(iOS 17.5, macOS 14.5, visionOS 26.2, *)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)public enum PencilSqueezeGesturePhase : Swift.Equatable {
+  case active(PencilSqueezeGestureValue)
+  case ended(PencilSqueezeGestureValue)
+  case failed
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public enum AsyncImagePhase : Swift.Sendable {
+  case empty
+  case success(Image)
+  case failure(any Swift.Error)
+}
+
+@available(iOS 13.0, tvOS 13.0, *)
+@available(macOS, unavailable)
+@available(watchOS, unavailable)
+public enum EditMode : Swift.Sendable {
+  case inactive
+  case transient
+  case active
+}
+
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
+public enum TextSelectionAffinity : Swift.Equatable, Swift.Hashable {
+  case automatic
+  case upstream
+  case downstream
+}

--- a/Sources/_SwiftCrossUIPortingKit/Generated/Enums.swift
+++ b/Sources/_SwiftCrossUIPortingKit/Generated/Enums.swift
@@ -2,45 +2,69 @@ import CoreFoundation
 import Foundation
 import SwiftCrossUI
 
-
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public enum LayoutDirection : Swift.Hashable, Swift.CaseIterable, Swift.Sendable {
-  case leftToRight
-  case rightToLeft
+    case leftToRight
+    case rightToLeft
 }
 
-@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)public enum ScrollPhase : Swift.Equatable {
-  case idle
-  case tracking
-  case interacting
-  case decelerating
-  case animating
+@available(
+    iOS 18.0,
+    macOS 15.0,
+    tvOS 18.0,
+    watchOS 11.0,
+    visionOS 2.0,
+    *
+)public enum ScrollPhase : Swift.Equatable {
+    case idle
+    case tracking
+    case interacting
+    case decelerating
+    case animating
 }
 
-@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)public enum HorizontalDirection : Swift.Int8, Swift.CaseIterable, Swift.Codable {
-  case leading
-  case trailing
+@available(
+    iOS 18.0,
+    macOS 15.0,
+    tvOS 18.0,
+    watchOS 11.0,
+    visionOS 2.0,
+    *
+)public enum HorizontalDirection : Swift.Int8, Swift.CaseIterable, Swift.Codable {
+    case leading
+    case trailing
 }
 
-@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)public enum VerticalDirection : Swift.Int8, Swift.CaseIterable, Swift.Codable {
-  case up
-  case down
+@available(
+    iOS 18.0,
+    macOS 15.0,
+    tvOS 18.0,
+    watchOS 11.0,
+    visionOS 2.0,
+    *
+)public enum VerticalDirection : Swift.Int8, Swift.CaseIterable, Swift.Codable {
+    case up
+    case down
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)public enum HorizontalEdge : Swift.Int8, Swift.CaseIterable, Swift.Codable {
-  case leading
-  case trailing
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)public enum HorizontalEdge : Swift.Int8,
+    Swift.CaseIterable, Swift.Codable
+{
+    case leading
+    case trailing
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)public enum VerticalEdge : Swift.Int8, Swift.CaseIterable, Swift.Codable {
-  case top
-  case bottom
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)public enum VerticalEdge : Swift.Int8,
+    Swift.CaseIterable, Swift.Codable
+{
+    case top
+    case bottom
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public enum TimelineScheduleMode : Swift.Sendable {
-  case normal
-  case lowFrequency
+    case normal
+    case lowFrequency
 }
 
 @available(macOS 26.0, visionOS 26.0, *)
@@ -48,67 +72,73 @@ public enum TimelineScheduleMode : Swift.Sendable {
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)
 public enum WorldRecenterPhase : Swift.Sendable {
-  case began
-  case ended
+    case began
+    case ended
 }
 
 @available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
 public enum LayoutDirectionBehavior : Swift.Hashable, Swift.Sendable {
-  case fixed
-  case mirrors(in: LayoutDirection)
+    case fixed
+    case mirrors(in: LayoutDirection)
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public enum ColorRenderingMode : Swift.Sendable {
-  case nonLinear
-  case linear
-  case extendedLinear
+    case nonLinear
+    case linear
+    case extendedLinear
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)public enum AccessibilityHeadingLevel : Swift.UInt {
-  case unspecified
-  case h1
-  case h2
-  case h3
-  case h4
-  case h5
-  case h6
+@available(
+    iOS 15.0,
+    macOS 12.0,
+    tvOS 15.0,
+    watchOS 8.0,
+    *
+)public enum AccessibilityHeadingLevel : Swift.UInt {
+    case unspecified
+    case h1
+    case h2
+    case h3
+    case h4
+    case h5
+    case h6
 }
 
 @available(iOS 15.0, macOS 10.15, tvOS 15.0, visionOS 1.0, watchOS 9.0, *)
 public enum ControlSize : Swift.CaseIterable, Swift.Sendable {
-  case mini
-  case small
-  case regular
-  @available(macOS 11.0, *)
-  case large
-  @available(iOS 17.0, macOS 14.0, tvOS 17.0, visionOS 1.0, watchOS 10.0, *)
-  case extraLarge
+    case mini
+    case small
+    case regular
+    @available(macOS 11.0, *)
+    case large
+    @available(iOS 17.0, macOS 14.0, tvOS 17.0, visionOS 1.0, watchOS 10.0, *)
+    case extraLarge
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public enum BlendMode : Swift.Sendable {
-  case normal
-  case multiply
-  case screen
-  case overlay
-  case darken
-  case lighten
-  case colorDodge
-  case colorBurn
-  case softLight
-  case hardLight
-  case difference
-  case exclusion
-  case hue
-  case saturation
-  case color
-  case luminosity
-  case sourceAtop
-  case destinationOver
-  case destinationOut
-  case plusDarker
-  case plusLighter
+    case normal
+    case multiply
+    case screen
+    case overlay
+    case darken
+    case lighten
+    case colorDodge
+    case colorBurn
+    case softLight
+    case hardLight
+    case difference
+    case exclusion
+    case hue
+    case saturation
+    case color
+    case luminosity
+    case sourceAtop
+    case destinationOver
+    case destinationOut
+    case plusDarker
+    case plusLighter
 }
 
 @available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, visionOS 26.0, *)
@@ -117,25 +147,25 @@ public enum AttributedTextFormatting {
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public enum ShapeRole : Swift.Sendable {
-  case fill
-  case stroke
-  case separator
+    case fill
+    case stroke
+    case separator
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public enum DynamicTypeSize : Swift.Hashable, Swift.Comparable, Swift.CaseIterable, Swift.Sendable {
-  case xSmall
-  case small
-  case medium
-  case large
-  case xLarge
-  case xxLarge
-  case xxxLarge
-  case accessibility1
-  case accessibility2
-  case accessibility3
-  case accessibility4
-  case accessibility5
+    case xSmall
+    case small
+    case medium
+    case large
+    case xLarge
+    case xxLarge
+    case xxxLarge
+    case accessibility1
+    case accessibility2
+    case accessibility3
+    case accessibility4
+    case accessibility5
 }
 
 @available(iOS, introduced: 13.0, deprecated: 100000.0, renamed: "DynamicTypeSize")
@@ -144,18 +174,18 @@ public enum DynamicTypeSize : Swift.Hashable, Swift.Comparable, Swift.CaseIterab
 @available(watchOS, introduced: 6.0, deprecated: 100000.0, renamed: "DynamicTypeSize")
 @available(visionOS, introduced: 1.0, deprecated: 100000.0, renamed: "DynamicTypeSize")
 public enum ContentSizeCategory : Swift.Hashable, Swift.CaseIterable, Swift.Sendable {
-  case extraSmall
-  case small
-  case medium
-  case large
-  case extraLarge
-  case extraExtraLarge
-  case extraExtraExtraLarge
-  case accessibilityMedium
-  case accessibilityLarge
-  case accessibilityExtraLarge
-  case accessibilityExtraExtraLarge
-  case accessibilityExtraExtraExtraLarge
+    case extraSmall
+    case small
+    case medium
+    case large
+    case extraLarge
+    case extraExtraLarge
+    case extraExtraExtraLarge
+    case accessibilityMedium
+    case accessibilityLarge
+    case accessibilityExtraLarge
+    case accessibilityExtraExtraLarge
+    case accessibilityExtraExtraExtraLarge
 }
 
 @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
@@ -164,100 +194,118 @@ public enum SystemFormatStyle : Swift.Sendable {
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public enum Prominence : Swift.Sendable {
-  case standard
-  case increased
+    case standard
+    case increased
 }
 
 @available(macOS 26.0, visionOS 2.0, *)
 @available(iOS, unavailable)
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)public enum Chirality : Swift.Hashable, Swift.Sendable {
-  case left
-  case right
+    case left
+    case right
 }
 
 @available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)public enum TransitionPhase {
-  case willAppear
-  case identity
-  case didDisappear
+    case willAppear
+    case identity
+    case didDisappear
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public enum CoordinateSpace {
-  case global
-  case local
-  case named(Swift.AnyHashable)
+    case global
+    case local
+    case named(Swift.AnyHashable)
 }
 
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)public enum TextAlignment : Swift.Hashable, Swift.CaseIterable {
-  case leading
-  case center
-  case trailing
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)public enum TextAlignment : Swift
+    .Hashable, Swift.CaseIterable
+{
+    case leading
+    case center
+    case trailing
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public enum UserInterfaceSizeClass : Swift.Sendable {
-  case compact
-  case regular
+    case compact
+    case regular
 }
 
 @available(iOS, unavailable)
-@available(macCatalyst, introduced: 13.0, deprecated: 100000.0, message: "Use `EnvironmentValues.appearsActive` instead.")
-@available(macOS, introduced: 10.15, deprecated: 100000.0, message: "Use `EnvironmentValues.appearsActive` instead.")
+@available(
+    macCatalyst,
+    introduced: 13.0,
+    deprecated: 100000.0,
+    message: "Use `EnvironmentValues.appearsActive` instead."
+)
+@available(
+    macOS,
+    introduced: 10.15,
+    deprecated: 100000.0,
+    message: "Use `EnvironmentValues.appearsActive` instead."
+)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 @available(visionOS, unavailable)
 public enum ControlActiveState : Swift.Equatable, Swift.CaseIterable, Swift.Sendable {
-  case key
-  case active
-  case inactive
+    case key
+    case active
+    case inactive
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public enum LegibilityWeight : Swift.Hashable, Swift.Sendable {
-  case regular
-  case bold
+    case regular
+    case bold
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public enum ColorSchemeContrast : Swift.CaseIterable, Swift.Sendable {
-  case standard
-  case increased
+    case standard
+    case increased
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public enum RoundedCornerStyle : Swift.Sendable {
-  case circular
-  case continuous
+    case circular
+    case continuous
 }
 
-@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)public enum AccessibilityLabeledPairRole {
-  case label
-  case content
+@available(
+    iOS 14.0,
+    macOS 11.0,
+    tvOS 14.0,
+    watchOS 7.0,
+    *
+)public enum AccessibilityLabeledPairRole {
+    case label
+    case content
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public enum AccessibilityAdjustmentDirection : Swift.Sendable {
-  case increment
-  case decrement
+    case increment
+    case decrement
 }
 
 @available(iOS 13.4, macOS 10.15, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 public enum DropOperation : Swift.Sendable {
-  case cancel
-  case forbidden
-  case copy
-  case move
-  @available(macOS 26.0, *)
-  @available(iOS, unavailable)
-  @available(visionOS, unavailable)
-  case delete
-  @available(macOS 26.0, *)
-  @available(iOS, unavailable)
-  @available(visionOS, unavailable)
-  case alias
+    case cancel
+    case forbidden
+    case copy
+    case move
+    @available(macOS 26.0, *)
+    @available(iOS, unavailable)
+    @available(visionOS, unavailable)
+    case delete
+    @available(macOS 26.0, *)
+    @available(iOS, unavailable)
+    @available(visionOS, unavailable)
+    case alias
 }
 
 @available(macOS 10.15, *)
@@ -266,34 +314,34 @@ public enum DropOperation : Swift.Sendable {
 @available(watchOS, unavailable)
 @available(visionOS, unavailable)
 public enum TouchBarItemPresence : Swift.Sendable {
-  case required(_: Swift.String)
-  case `default`(_: Swift.String)
-  case optional(_: Swift.String)
+    case required(_: Swift.String)
+    case `default`(_: Swift.String)
+    case optional(_: Swift.String)
 }
 
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
 @available(watchOS, unavailable)public enum HoverPhase : Swift.Equatable {
-  case active(CoreFoundation.CGPoint)
-  case ended
+    case active(CoreFoundation.CGPoint)
+    case ended
 }
 
 @available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, visionOS 26.0, *)
 public enum TabViewBottomAccessoryPlacement : Swift.Hashable, Swift.Sendable {
-  case inline
-  case expanded
+    case inline
+    case expanded
 }
 
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 public enum ScenePhase : Swift.Comparable {
-  case background
-  case inactive
-  case active
+    case background
+    case inactive
+    case active
 }
 
 @available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)public enum ScrollTransitionPhase {
-  case topLeading
-  case identity
-  case bottomTrailing
+    case topLeading
+    case identity
+    case bottomTrailing
 }
 
 @available(macOS 15.0, *)
@@ -301,14 +349,14 @@ public enum ScenePhase : Swift.Comparable {
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 @available(visionOS, unavailable)public enum FrameResizePosition : Swift.Int8, Swift.CaseIterable {
-  case top
-  case leading
-  case bottom
-  case trailing
-  case topLeading
-  case topTrailing
-  case bottomLeading
-  case bottomTrailing
+    case top
+    case leading
+    case bottom
+    case trailing
+    case topLeading
+    case topTrailing
+    case bottomLeading
+    case bottomTrailing
 }
 
 @available(macOS 15.0, *)
@@ -316,29 +364,29 @@ public enum ScenePhase : Swift.Comparable {
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 @available(visionOS, unavailable)public enum FrameResizeDirection : Swift.Int8, Swift.CaseIterable {
-  case inward
-  case outward
+    case inward
+    case outward
 }
 
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
 public enum SidebarRowSize : Swift.Sendable {
-  case small
-  case medium
-  case large
+    case small
+    case medium
+    case large
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public enum PreviewPlatform : Swift.Sendable {
-  case iOS
-  case macOS
-  case tvOS
-  case watchOS
+    case iOS
+    case macOS
+    case tvOS
+    case watchOS
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 public enum PopoverAttachmentAnchor {
-  case rect(Anchor<CoreFoundation.CGRect>.Source)
-  case point(UnitPoint)
+    case rect(Anchor<CoreFoundation.CGRect>.Source)
+    case point(UnitPoint)
 }
 
 @available(macOS 10.15, tvOS 13.0, *)
@@ -346,39 +394,39 @@ public enum PopoverAttachmentAnchor {
 @available(watchOS, unavailable)
 @available(visionOS, unavailable)
 public enum MoveCommandDirection : Swift.Sendable {
-  case up
-  case down
-  case left
-  case right
+    case up
+    case down
+    case left
+    case right
 }
 
 @available(iOS 17.5, macOS 14.5, visionOS 26.2, *)
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)public enum PencilSqueezeGesturePhase : Swift.Equatable {
-  case active(PencilSqueezeGestureValue)
-  case ended(PencilSqueezeGestureValue)
-  case failed
+    case active(PencilSqueezeGestureValue)
+    case ended(PencilSqueezeGestureValue)
+    case failed
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public enum AsyncImagePhase : Swift.Sendable {
-  case empty
-  case success(Image)
-  case failure(any Swift.Error)
+    case empty
+    case success(Image)
+    case failure(any Swift.Error)
 }
 
 @available(iOS 13.0, tvOS 13.0, *)
 @available(macOS, unavailable)
 @available(watchOS, unavailable)
 public enum EditMode : Swift.Sendable {
-  case inactive
-  case transient
-  case active
+    case inactive
+    case transient
+    case active
 }
 
 @available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
 public enum TextSelectionAffinity : Swift.Equatable, Swift.Hashable {
-  case automatic
-  case upstream
-  case downstream
+    case automatic
+    case upstream
+    case downstream
 }

--- a/Sources/_SwiftCrossUIPortingKit/Structs.swift
+++ b/Sources/_SwiftCrossUIPortingKit/Structs.swift
@@ -1,0 +1,5 @@
+public struct Anchor<T> {
+    public struct Source {}
+}
+
+public struct PencilSqueezeGestureValue: Equatable {}


### PR DESCRIPTION
This PR introduces APITool: a tool specifically built for diffing the API surfaces of SwiftUI and SwiftCrossUI to help track the progress of SwiftCrossUI's development. Additionally, APITool can generate stubs for missing SwiftUI APIs. APITool's stub generation is very limited for now, and only supports enums. I hope that it can eventually also be used to generate subs for all of the view modifiers that SwiftCrossUI is currently missing, because missing view moddifiers are currently the biggest pain point when porting from SwiftUI to SwiftCrossUI, and having them stubbed out automatically would mean that you can get a compiling app faster, and worry about the details once you already have a tangible proof of concept for your porting effort. The generated stubs live in _SwiftCrossUIPortingKit, which porters can import into their project to access no-op stubs for missing SwiftCrossUI APIs.

This PR is a step towards #717

---

This PR also updates `Scripts/format.sh` to evaluate its first argument (the path to format) relative to the directory that the script was run in (instead of always being relative to the SCUI root directory). I've also updated it to only run SwiftFormat when there are swift files to format, and to only run ktfmt when there are Kotlin files to format (ktfmt produces a failure error status when it can't find any Kotlin files to format).