### PR TITLE
Support view-body `return` expressions by dispatching to expected view lifecycle hooks

### DIFF
--- a/Sources/SwiftCrossUI/Environment/EnvironmentValues.swift
+++ b/Sources/SwiftCrossUI/Environment/EnvironmentValues.swift
@@ -240,19 +240,19 @@ extension EnvironmentValues {
     ///
     /// Inherited by ``ForEach`` and ``Group`` so that they can be used without
     /// affecting layout.
-    @Entry public var layoutOrientation: Orientation = .vertical
+    @Entry public var layoutOrientation: Orientation = StackLayoutContext.default.orientation
 
     /// The current stack alignment.
     ///
     /// Inherited by ``ForEach`` and ``Group`` so that they can be used without
     /// affecting layout.
-    @Entry public var layoutAlignment: StackAlignment = .center
+    @Entry public var layoutAlignment: StackAlignment = StackLayoutContext.default.alignment
 
     /// The current stack spacing.
     ///
     /// Inherited by ``ForEach`` and ``Group`` so that they can be used without
     /// affecting layout.
-    @Entry public var layoutSpacing: Int = 10
+    @Entry public var layoutSpacing: Int = StackLayoutContext.default.spacing
 
     /// The current font.
     @Entry public var font: Font = .body
@@ -492,7 +492,6 @@ extension EnvironmentValues {
         return string
     }
 }
-
 
 /// A key that can be used to extend the environment with new properties.
 public protocol EnvironmentKey<Value> {

--- a/Sources/SwiftCrossUI/Layout/StackLayoutContext.swift
+++ b/Sources/SwiftCrossUI/Layout/StackLayoutContext.swift
@@ -1,0 +1,50 @@
+/// The orientation, alignment and spacing that a stack imposes on its children.
+///
+/// These three values travel together through the environment; grouping them
+/// keeps their defaults in one place and lets a view establish a complete stack
+/// context in a single step.
+public struct StackLayoutContext: Sendable {
+    /// The orientation children are laid out along.
+    public var orientation: Orientation
+    /// The alignment of children perpendicular to ``orientation``.
+    public var alignment: StackAlignment
+    /// The amount of spacing to apply between children.
+    public var spacing: Int
+
+    /// The context a view lays out in when no stack has established one.
+    ///
+    /// Also the context that implicit stacks adopt: ``VStack`` and ``HStack``
+    /// fall back to its spacing and alignment, and a view body composed of
+    /// several views is stacked with it rather than inheriting the surrounding
+    /// stack's context.
+    public static let `default` = StackLayoutContext(
+        orientation: .vertical,
+        alignment: .center,
+        spacing: 10
+    )
+
+    /// Creates a stack layout context.
+    ///
+    /// - Parameters:
+    ///   - orientation: The orientation children are laid out along.
+    ///   - alignment: The alignment of children perpendicular to `orientation`.
+    ///   - spacing: The amount of spacing to apply between children.
+    public init(orientation: Orientation, alignment: StackAlignment, spacing: Int) {
+        self.orientation = orientation
+        self.alignment = alignment
+        self.spacing = spacing
+    }
+}
+
+extension EnvironmentValues {
+    /// Returns a copy of the environment with the given stack layout context
+    /// applied.
+    ///
+    /// - Parameter context: The context to impose on children.
+    /// - Returns: A copy of the environment laying children out with `context`.
+    public func with(_ context: StackLayoutContext) -> Self {
+        with(\.layoutOrientation, context.orientation)
+            .with(\.layoutAlignment, context.alignment)
+            .with(\.layoutSpacing, context.spacing)
+    }
+}

--- a/Sources/SwiftCrossUI/Layout/StackLayoutContext.swift
+++ b/Sources/SwiftCrossUI/Layout/StackLayoutContext.swift
@@ -3,13 +3,13 @@
 /// These three values travel together through the environment; grouping them
 /// keeps their defaults in one place and lets a view establish a complete stack
 /// context in a single step.
-public struct StackLayoutContext: Sendable {
+struct StackLayoutContext: Sendable {
     /// The orientation children are laid out along.
-    public var orientation: Orientation
+    var orientation: Orientation
     /// The alignment of children perpendicular to ``orientation``.
-    public var alignment: StackAlignment
+    var alignment: StackAlignment
     /// The amount of spacing to apply between children.
-    public var spacing: Int
+    var spacing: Int
 
     /// The context a view lays out in when no stack has established one.
     ///
@@ -17,7 +17,7 @@ public struct StackLayoutContext: Sendable {
     /// fall back to its spacing and alignment, and a view body composed of
     /// several views is stacked with it rather than inheriting the surrounding
     /// stack's context.
-    public static let `default` = StackLayoutContext(
+    static let `default` = StackLayoutContext(
         orientation: .vertical,
         alignment: .center,
         spacing: 10
@@ -29,7 +29,7 @@ public struct StackLayoutContext: Sendable {
     ///   - orientation: The orientation children are laid out along.
     ///   - alignment: The alignment of children perpendicular to `orientation`.
     ///   - spacing: The amount of spacing to apply between children.
-    public init(orientation: Orientation, alignment: StackAlignment, spacing: Int) {
+    init(orientation: Orientation, alignment: StackAlignment, spacing: Int) {
         self.orientation = orientation
         self.alignment = alignment
         self.spacing = spacing
@@ -42,7 +42,7 @@ extension EnvironmentValues {
     ///
     /// - Parameter context: The context to impose on children.
     /// - Returns: A copy of the environment laying children out with `context`.
-    public func with(_ context: StackLayoutContext) -> Self {
+    func with(_ context: StackLayoutContext) -> Self {
         with(\.layoutOrientation, context.orientation)
             .with(\.layoutAlignment, context.alignment)
             .with(\.layoutSpacing, context.spacing)

--- a/Sources/SwiftCrossUI/Views/HStack.swift
+++ b/Sources/SwiftCrossUI/Views/HStack.swift
@@ -7,6 +7,15 @@ public struct HStack<Content: View>: View {
     /// The alignment of the stack's children in the vertical direction.
     private var alignment: VerticalAlignment
 
+    /// The context this stack imposes on its children.
+    private var layoutContext: StackLayoutContext {
+        StackLayoutContext(
+            orientation: .horizontal,
+            alignment: alignment.asStackAlignment,
+            spacing: spacing
+        )
+    }
+
     /// Creates a horizontal stack with the given spacing and alignment.
     ///
     /// - Parameters:
@@ -20,7 +29,7 @@ public struct HStack<Content: View>: View {
         @ViewBuilder _ content: () -> Content
     ) {
         body = content()
-        self.spacing = spacing ?? VStack<EmptyView>.defaultSpacing
+        self.spacing = spacing ?? StackLayoutContext.default.spacing
         self.alignment = alignment
     }
 
@@ -54,10 +63,7 @@ public struct HStack<Content: View>: View {
             children: layoutableChildren(backend: backend, children: children),
             cache: &cache,
             proposedSize: proposedSize,
-            environment: environment
-                .with(\.layoutOrientation, .horizontal)
-                .with(\.layoutAlignment, alignment.asStackAlignment)
-                .with(\.layoutSpacing, spacing),
+            environment: environment.with(layoutContext),
             backend: backend
         )
         (children as? TupleViewChildren)?.stackLayoutCache = cache
@@ -77,10 +83,7 @@ public struct HStack<Content: View>: View {
             children: layoutableChildren(backend: backend, children: children),
             cache: &cache,
             layout: layout,
-            environment: environment
-                .with(\.layoutOrientation, .horizontal)
-                .with(\.layoutAlignment, alignment.asStackAlignment)
-                .with(\.layoutSpacing, spacing),
+            environment: environment.with(layoutContext),
             backend: backend
         )
         (children as? TupleViewChildren)?.stackLayoutCache = cache

--- a/Sources/SwiftCrossUI/Views/VStack.swift
+++ b/Sources/SwiftCrossUI/Views/VStack.swift
@@ -1,13 +1,20 @@
 /// A view that arranges its subviews vertically.
 public struct VStack<Content: View>: View {
-    static var defaultSpacing: Int { 10 }
-
     public var body: Content
 
     /// The amount of spacing to apply between children.
     private var spacing: Int
     /// The alignment of the stack's children in the horizontal direction.
     private var alignment: HorizontalAlignment
+
+    /// The context this stack imposes on its children.
+    private var layoutContext: StackLayoutContext {
+        StackLayoutContext(
+            orientation: .vertical,
+            alignment: alignment.asStackAlignment,
+            spacing: spacing
+        )
+    }
 
     /// Creates a vertical stack with the given spacing and alignment.
     ///
@@ -37,7 +44,7 @@ public struct VStack<Content: View>: View {
         content: Content
     ) {
         body = content
-        self.spacing = spacing ?? Self.defaultSpacing
+        self.spacing = spacing ?? StackLayoutContext.default.spacing
         self.alignment = alignment
     }
 
@@ -77,10 +84,7 @@ public struct VStack<Content: View>: View {
             children: layoutableChildren(backend: backend, children: children),
             cache: &cache,
             proposedSize: proposedSize,
-            environment: environment
-                .with(\.layoutOrientation, .vertical)
-                .with(\.layoutAlignment, alignment.asStackAlignment)
-                .with(\.layoutSpacing, spacing),
+            environment: environment.with(layoutContext),
             backend: backend
         )
         (children as? TupleViewChildren)?.stackLayoutCache = cache
@@ -100,10 +104,7 @@ public struct VStack<Content: View>: View {
             children: layoutableChildren(backend: backend, children: children),
             cache: &cache,
             layout: layout,
-            environment: environment
-                .with(\.layoutOrientation, .vertical)
-                .with(\.layoutAlignment, alignment.asStackAlignment)
-                .with(\.layoutSpacing, spacing),
+            environment: environment.with(layoutContext),
             backend: backend
         )
         (children as? TupleViewChildren)?.stackLayoutCache = cache

--- a/Sources/SwiftCrossUI/Views/View.swift
+++ b/Sources/SwiftCrossUI/Views/View.swift
@@ -172,8 +172,7 @@ extension View {
         _ children: any ViewGraphNodeChildren,
         backend: Backend
     ) -> Backend.Widget {
-        let vStack = VStack(content: body)
-        return vStack.asWidget(children, backend: backend)
+        body.asWidget(children, backend: backend)
     }
 
     public func computeLayout<Backend: BaseAppBackend>(
@@ -194,6 +193,10 @@ extension View {
 
     /// The default `View.computeLayout` implementation. Haters may see this as a
     /// composition lover re-implementing inheritance; I see it as innovation.
+    ///
+    /// A body composed of several views is stacked with
+    /// ``StackLayoutContext/default``, so it lays out the same wherever the view
+    /// is used rather than inheriting the surrounding stack's context.
     public func defaultComputeLayout<Backend: BaseAppBackend>(
         _ widget: Backend.Widget,
         children: any ViewGraphNodeChildren,
@@ -201,12 +204,11 @@ extension View {
         environment: EnvironmentValues,
         backend: Backend
     ) -> ViewLayoutResult {
-        let vStack = VStack(content: body)
-        return vStack.computeLayout(
+        body.computeLayout(
             widget,
             children: children,
             proposedSize: proposedSize,
-            environment: environment,
+            environment: environment.with(.default),
             backend: backend
         )
     }
@@ -227,6 +229,11 @@ extension View {
         )
     }
 
+    /// The default `View.commit` implementation.
+    ///
+    /// A body composed of several views is stacked with
+    /// ``StackLayoutContext/default``, matching
+    /// ``defaultComputeLayout(_:children:proposedSize:environment:backend:)``.
     public func defaultCommit<Backend: BaseAppBackend>(
         _ widget: Backend.Widget,
         children: any ViewGraphNodeChildren,
@@ -234,12 +241,11 @@ extension View {
         environment: EnvironmentValues,
         backend: Backend
     ) {
-        let vStack = VStack(content: body)
-        return vStack.commit(
+        body.commit(
             widget,
             children: children,
             layout: layout,
-            environment: environment,
+            environment: environment.with(.default),
             backend: backend
         )
     }

--- a/Tests/SwiftCrossUITests/ExplicitReturnCommitTests.swift
+++ b/Tests/SwiftCrossUITests/ExplicitReturnCommitTests.swift
@@ -1,0 +1,70 @@
+import Testing
+
+import DummyBackend
+@testable @_spi(Backends) import SwiftCrossUI
+
+/// A body the `@ViewBuilder` transform rewrites.
+struct BuilderBodyButton: View {
+    var body: some View {
+        Button("tap") {}
+    }
+}
+
+/// An explicit `return` opts the body out of the `@ViewBuilder` transform, so
+/// `body` is the bare view rather than a builder wrapper.
+struct ExplicitReturnBodyButton: View {
+    var body: some View {
+        return Button("tap") {}
+    }
+}
+
+@Suite("View bodies that opt out of the ViewBuilder transform")
+struct ExplicitReturnCommitTests {
+    let backend: DummyBackend
+    let window: DummyBackend.Window
+    let environment: EnvironmentValues
+
+    @MainActor
+    init() {
+        backend = DummyBackend()
+        window = backend.createWindow(withDefaultSize: nil, id: "window")
+        environment = EnvironmentValues(backend: backend).with(\.window, window)
+    }
+
+    @MainActor
+    func button<V: View>(of view: V) -> DummyBackend.Button? {
+        let node = ViewGraphNode(for: view, backend: backend, environment: environment)
+        _ = node.computeLayout(
+            proposedSize: ProposedViewSize(200, 200),
+            environment: environment
+        )
+        _ = node.commit()
+
+        func firstButton(in widget: DummyBackend.Widget) -> DummyBackend.Button? {
+            if let button = widget as? DummyBackend.Button {
+                return button
+            }
+            return widget.getChildren().lazy.compactMap(firstButton(in:)).first
+        }
+
+        return firstButton(in: node.widget)
+    }
+
+    @MainActor
+    @Test("A builder-shaped body renders a working button")
+    func builderBodyRendersButton() throws {
+        let button = try #require(button(of: BuilderBodyButton()))
+
+        #expect(button.action != nil)
+        #expect(button.size == SIMD2<Int>(24, 16))
+    }
+
+    @MainActor
+    @Test("An explicit-return body renders a working button")
+    func explicitReturnBodyRendersButton() throws {
+        let button = try #require(button(of: ExplicitReturnBodyButton()))
+
+        #expect(button.action != nil)
+        #expect(button.size == SIMD2<Int>(24, 16))
+    }
+}

--- a/Tests/SwiftCrossUITests/ExplicitReturnCommitTests.swift
+++ b/Tests/SwiftCrossUITests/ExplicitReturnCommitTests.swift
@@ -32,7 +32,7 @@ struct ExplicitReturnCommitTests {
     }
 
     @MainActor
-    func button<V: View>(of view: V) -> DummyBackend.Button? {
+    func findButton<V: View>(of view: V) -> DummyBackend.Button? {
         let node = ViewGraphNode(for: view, backend: backend, environment: environment)
         _ = node.computeLayout(
             proposedSize: ProposedViewSize(200, 200),
@@ -53,7 +53,7 @@ struct ExplicitReturnCommitTests {
     @MainActor
     @Test("A builder-shaped body renders a working button")
     func builderBodyRendersButton() throws {
-        let button = try #require(button(of: BuilderBodyButton()))
+        let button = try #require(findButton(of: BuilderBodyButton()))
 
         #expect(button.action != nil)
         #expect(button.size == SIMD2<Int>(24, 16))
@@ -62,7 +62,7 @@ struct ExplicitReturnCommitTests {
     @MainActor
     @Test("An explicit-return body renders a working button")
     func explicitReturnBodyRendersButton() throws {
-        let button = try #require(button(of: ExplicitReturnBodyButton()))
+        let button = try #require(findButton(of: ExplicitReturnBodyButton()))
 
         #expect(button.action != nil)
         #expect(button.size == SIMD2<Int>(24, 16))


### PR DESCRIPTION
Fixes #725.

```swift
struct Works: View {
    var body: some View {
        Button("tap") {}
    }
}

struct FixedWithThisPR: View {
    var body: some View {
        return Button("tap") {}
    }
}
```
I did a deeper dive on the root issue in #725.

This PR:
1. Adds a (currently-_internal_) `StackLayoutContext` to capture the defaults that were distributed. Backwards-compatible shims ensure no user-side code-changes.
2. The lifecycle methods that previously had been pointed at the wrapper now correctly delegate to the body's implementation(s).

The most interesting changes are in `Sources/SwiftCrossUI/Views/View.swift`

**LLM Usage:** *I used Claude to root cause the issue, build the reproduction, and prepare the patch, which I analyzed and directed. I entirely manually authored this description. I take responsibility for everything in this PR.*