### PR TITLE
StackLayout now gets propagated to children #728

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e1d47171a0f09d7abb802e04c331d0a0a5062a8b24a023170a5295c7a5107321",
+  "originHash" : "fdd258e4708a1f880a760515c448e205b7ac32748fdb7e3fecdbf405a74025fa",
   "pins" : [
     {
       "identity" : "androidkit",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-android-sdk/swift-android-native.git",
       "state" : {
-        "revision" : "6ff6e6274fccafac7fdabb4cf7c958d747f44831",
-        "version" : "2.0.1"
+        "revision" : "5f71c1584b3cbe3842d335ebb4d7b545205d9945",
+        "version" : "2.1.0"
       }
     },
     {
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system",
       "state" : {
-        "revision" : "7502b711c92a17741fa625d722b0ccbd595d8ed1",
-        "version" : "1.7.2"
+        "revision" : "869129b7bf4ecc57b97d0193ad29690ca2134750",
+        "version" : "1.8.1"
       }
     },
     {

--- a/Sources/SwiftCrossUI/Environment/EnvironmentValues.swift
+++ b/Sources/SwiftCrossUI/Environment/EnvironmentValues.swift
@@ -247,10 +247,10 @@ extension EnvironmentValues {
     /// Inherited by ``ForEach`` and ``Group`` so that they can be used without
     /// affecting layout.
     @Entry public var layoutAlignment: StackAlignment = .center
-    
+
     /// Whether to use the ZStack StackLayout variants.
     @Entry public var usesZStackLayout: Bool = false
-    
+
     /// The alignment of content inside a ``ZStack``.
     /// Only gets used when ``usesZStackLayout`` is `true`.
     @Entry public var zStackContentAlignment: Alignment = .center

--- a/Sources/SwiftCrossUI/Environment/EnvironmentValues.swift
+++ b/Sources/SwiftCrossUI/Environment/EnvironmentValues.swift
@@ -247,6 +247,13 @@ extension EnvironmentValues {
     /// Inherited by ``ForEach`` and ``Group`` so that they can be used without
     /// affecting layout.
     @Entry public var layoutAlignment: StackAlignment = .center
+    
+    /// Whether to use the ZStack StackLayout variants.
+    @Entry public var usesZStackLayout: Bool = false
+    
+    /// The alignment of content inside a ``ZStack``.
+    /// Only gets used when ``usesZStackLayout`` is `true`.
+    @Entry public var zStackContentAlignment: Alignment = .center
 
     /// The current stack spacing.
     ///

--- a/Sources/SwiftCrossUI/Layout/LayoutSystem.swift
+++ b/Sources/SwiftCrossUI/Layout/LayoutSystem.swift
@@ -520,11 +520,6 @@ public enum LayoutSystem {
             cache = StackLayoutCache(
                 priorityGroups: [group],
                 isHidden: results.map(\.participatesInStackLayouts).map(!),
-                // TODO(stackotter): How does SwiftUI handle space reservation during
-                //   relayouts? I feel like it probably doesn't use minimum lengths if
-                //   it didn't already have to during the initial layout pass because
-                //   the alternative would be expensive, but that approach would also
-                //   be a bit inconsistent
                 totalSpacing: 0,
                 totalReservedSpace: 0,
                 minimumLengths: [Double](repeating: 0, count: children.count),

--- a/Sources/SwiftCrossUI/Layout/LayoutSystem.swift
+++ b/Sources/SwiftCrossUI/Layout/LayoutSystem.swift
@@ -132,7 +132,7 @@ public enum LayoutSystem {
         let perpendicularOrientation = orientation.perpendicular
 
         let stackLength = proposedSize[component: orientation]
-        if stackLength == 0 || stackLength == .infinity || stackLength == nil || children.count == 1
+        if stackLength == 0 || stackLength == .infinity || stackLength == nil || children.count <= 1
         {
             var resultLength: Double = 0
             var resultWidth: Double = 0
@@ -494,21 +494,22 @@ public enum LayoutSystem {
         backend: Backend,
         inheritStackLayoutParticipation: Bool = false
     ) -> ViewLayoutResult {
-        if children.count == 1 {
-            var maxWidth: Double = 0
-            var maxHeight: Double = 0
+        let specialSizes: [Double?] = [nil, .infinity]
+        if children.count <= 1 || (specialSizes.contains(proposedSize.width) && specialSizes.contains(proposedSize.height)) {
+            var stackWidth: Double = 0
+            var stackHeight: Double = 0
             var results: [ViewLayoutResult] = []
             for child in children {
                 let result = child.computeLayout(
                     proposedSize: proposedSize,
                     environment: environment
                 )
-                maxWidth = max(maxWidth, result.size.width)
-                maxHeight = max(maxHeight, result.size.height)
+                stackWidth = max(stackWidth, result.size.width)
+                stackHeight = max(stackHeight, result.size.height)
                 results.append(result)
             }
 
-            let size = ViewSize(maxWidth, maxHeight)
+            let size = ViewSize(stackWidth, stackHeight)
 
             // In this case, flexibility and layout priority don't matter. We set
             // the grouping to the trivial grouping so that commitStackLayout
@@ -519,11 +520,11 @@ public enum LayoutSystem {
             )
             cache = StackLayoutCache(
                 priorityGroups: [group],
-                isHidden: results.map(\.participatesInStackLayouts).map(!),
+                isHidden: [false],
                 totalSpacing: 0,
                 totalReservedSpace: 0,
                 minimumLengths: [Double](repeating: 0, count: children.count),
-                redistributeSpaceOnCommit: false
+                redistributeSpaceOnCommit: proposedSize.width == nil || proposedSize.height == nil
             )
 
             return ViewLayoutResult(
@@ -545,8 +546,7 @@ public enum LayoutSystem {
             of: children,
             proposedSize: proposedSize,
             cache: cache,
-            environment: environment,
-            ignoreHiddenChildrenEntirely: false
+            environment: environment
         )
 
         var size = ViewSize.zero
@@ -570,29 +570,18 @@ public enum LayoutSystem {
         let minimumProposedSize = ProposedViewSize(0, 0)
         let maximumProposedSize = ProposedViewSize(.infinity, .infinity)
 
-        var isHidden = [Bool](repeating: false, count: children.count)
         var priorities = [Double](repeating: 0, count: children.count)
 
-        let flexibilities = children.enumerated().map { i, child in
+        for (i, child) in children.enumerated() {
             let minimumResult = child.computeLayout(
                 proposedSize: minimumProposedSize,
                 environment: environment.with(\.allowLayoutCaching, true)
             )
-            let maximumResult = child.computeLayout(
-                proposedSize: maximumProposedSize,
-                environment: environment.with(\.allowLayoutCaching, true)
-            )
 
-            isHidden[i] = !minimumResult.participatesInStackLayouts
             priorities[i] = minimumResult.preferences.layoutPriority
-
-            let widthFlexibility = maximumResult.size.width - minimumResult.size.width
-            let heightFlexibility = maximumResult.size.height - minimumResult.size.height
-
-            return widthFlexibility + heightFlexibility
         }
 
-        let sortedChildren = zip(children.indices, zip(priorities.map(-), flexibilities))
+        let sortedChildren = zip(children.indices, priorities.map(-))
             .sorted { first, second in
                 // Sort by descending priority and then by ascending flexibility
                 first.1 <= second.1
@@ -632,7 +621,7 @@ public enum LayoutSystem {
 
         return StackLayoutCache(
             priorityGroups: priorityGroups,
-            isHidden: isHidden,
+            isHidden: [false],
             totalSpacing: 0,
             totalReservedSpace: 0,
             minimumLengths: [],
@@ -640,63 +629,48 @@ public enum LayoutSystem {
         )
     }
 
-    /// The main ZStack layout space allocation algorithm. Used during computeLayout.
+    /// The main ZStack layout algorithm. Used during computeZStackLayout
     @MainActor
     static func computeZStackLayouts(
         of children: [LayoutableChild],
         proposedSize: ProposedViewSize,
         cache: StackLayoutCache,
-        environment: EnvironmentValues,
-        ignoreHiddenChildrenEntirely: Bool
+        environment: EnvironmentValues
     ) -> [ViewLayoutResult] {
         var renderedChildren = [ViewLayoutResult](
             repeating: .leafView(size: .zero),
             count: children.count
         )
+        
+        var currentProposedSize = proposedSize
 
         for group in cache.priorityGroups {
-            var childrenRemaining = group.children.count { index in
-                !cache.isHidden[index]
-            }
-
+            var maxSize: ProposedViewSize = .zero
+            
             for index in group.children {
                 let child = children[index]
 
-                // No need to render visible children.
-                if cache.isHidden[index] {
-                    if ignoreHiddenChildrenEntirely {
-                        continue
-                    }
-
-                    // Update child in case it has just changed from visible to hidden,
-                    // and to make sure that the view is still hidden (if it's not then
-                    // it's a bug with either the view or the layout system).
-                    let result = child.computeLayout(
-                        proposedSize: .zero,
-                        environment: environment
-                    )
-                    if result.participatesInStackLayouts {
-                        logger.warning(
-                            "hidden view became visible on second update; layout may break",
-                            metadata: [
-                                "view": "\(child.tag ?? "<unknown type>")"
-                            ]
-                        )
-                    }
-                    renderedChildren[index] = result
-                    renderedChildren[index].participateInStackLayoutsWhenEmpty = false
-                    renderedChildren[index].size = .zero
-                    continue
-                }
-
                 let childResult = child.computeLayout(
-                    proposedSize: proposedSize,
+                    proposedSize: currentProposedSize,
                     environment: environment
                 )
+                
+                if let currentMaxWidth = maxSize.width {
+                    maxSize.width = max(childResult.size.width, currentMaxWidth)
+                } else {
+                    maxSize.width = childResult.size.width
+                }
+                
+                if let currentMaxHeight = maxSize.height {
+                    maxSize.height = max(childResult.size.height, currentMaxHeight)
+                } else {
+                    maxSize.height = childResult.size.height
+                }
 
                 renderedChildren[index] = childResult
-                childrenRemaining -= 1
             }
+            
+            currentProposedSize = maxSize
         }
 
         return renderedChildren
@@ -715,13 +689,17 @@ public enum LayoutSystem {
         let alignment = environment.zStackContentAlignment
         backend.setSize(of: container, to: size.vector)
 
-        guard !cache.redistributeSpaceOnCommit else {
-            fatalError("unreachable")
+        if cache.redistributeSpaceOnCommit {
+            _ = computeZStackLayouts(
+                of: children,
+                proposedSize: ProposedViewSize(size.width, size.height),
+                cache: cache,
+                environment: environment
+            )
         }
-
+        
         let renderedChildren = children.map { $0.commit() }
 
-        var position = Position.zero
         for (index, child) in renderedChildren.enumerated() {
             // Avoid the whole iteration if the child is hidden. If there
             // are weird positioning issues for views that do strange things
@@ -729,79 +707,10 @@ public enum LayoutSystem {
             if !child.participatesInStackLayouts {
                 continue
             }
-
             // Compute alignment
-            switch alignment {
-                case .topLeading:
-                    position.x = 0
-                    position.y = 0
-                case .top:
-                    let outerX = size.width
-                    let innerX = child.size.width
-                    position.x = (outerX - innerX) / 2
-
-                    position.y = 0
-                case .topTrailing:
-                    let outerX = size.width
-                    let innerX = child.size.width
-                    position.x = outerX - innerX
-
-                    position.y = 0
-                case .leading:
-                    position.x = 0
-
-                    let outerY = size.height
-                    let innerY = child.size.height
-                    position.y = (outerY - innerY) / 2
-                case .center:
-                    let outerX = size.width
-                    let innerX = child.size.width
-                    position.x = (outerX - innerX) / 2
-
-                    let outerY = size.height
-                    let innerY = child.size.height
-                    position.y = (outerY - innerY) / 2
-                case .trailing:
-                    let outerX = size.width
-                    let innerX = child.size.width
-                    position.x = outerX - innerX
-
-                    let outerY = size.height
-                    let innerY = child.size.height
-                    position.y = (outerY - innerY) / 2
-                case .bottomLeading:
-                    position.x = 0
-
-                    let outerY = size.height
-                    let innerY = child.size.height
-                    position.y = outerY - innerY
-                case .bottom:
-                    let outerX = size.width
-                    let innerX = child.size.width
-                    position.x = (outerX - innerX) / 2
-
-                    let outerY = size.height
-                    let innerY = child.size.height
-                    position.y = outerY - innerY
-                case .bottomTrailing:
-                    let outerX = size.width
-                    let innerX = child.size.width
-                    position.x = outerX - innerX
-
-                    let outerY = size.height
-                    let innerY = child.size.height
-                    position.y = outerY - innerY
-                default:
-                    let outerX = size.width
-                    let innerX = child.size.width
-                    position.x = (outerX - innerX) / 2
-
-                    let outerY = size.height
-                    let innerY = child.size.height
-                    position.y = (outerY - innerY) / 2
-            }
-
-            backend.setPosition(ofChildAt: index, in: container, to: position.vector)
+            let position = alignment.position(ofChild: child.size.vector, in: size.vector)
+            
+            backend.setPosition(ofChildAt: index, in: container, to: position)
         }
     }
 }

--- a/Sources/SwiftCrossUI/Layout/LayoutSystem.swift
+++ b/Sources/SwiftCrossUI/Layout/LayoutSystem.swift
@@ -126,7 +126,7 @@ public enum LayoutSystem {
                 backend: backend
             )
         }
-        
+
         let spacing = environment.layoutSpacing
         let orientation = environment.layoutOrientation
         let perpendicularOrientation = orientation.perpendicular
@@ -350,10 +350,10 @@ public enum LayoutSystem {
                 environment: environment,
                 backend: backend
             )
-            
+
             return
         }
-        
+
         let size = layout.size
         backend.setSize(of: container, to: size.vector)
 
@@ -483,7 +483,7 @@ public enum LayoutSystem {
 
         return renderedChildren
     }
-    
+
     @MainActor
     static func computeZStackLayout<Backend: BaseAppBackend>(
         container: Backend.Widget,
@@ -507,9 +507,9 @@ public enum LayoutSystem {
                 maxHeight = max(maxHeight, result.size.height)
                 results.append(result)
             }
-            
+
             let size = ViewSize(maxWidth, maxHeight)
-            
+
             // In this case, flexibility and layout priority don't matter. We set
             // the grouping to the trivial grouping so that commitStackLayout
             // effectively ignores flexibility.
@@ -530,7 +530,7 @@ public enum LayoutSystem {
                 minimumLengths: [Double](repeating: 0, count: children.count),
                 redistributeSpaceOnCommit: false
             )
-            
+
             return ViewLayoutResult(
                 size: size,
                 childResults: results,
@@ -539,13 +539,13 @@ public enum LayoutSystem {
                 preferencesOverlay: nil
             )
         }
-        
+
         cache = recomputeZStackCache(
             children: children,
             proposedSize: proposedSize,
             environment: environment
         )
-        
+
         let renderedChildren = computeZStackLayouts(
             of: children,
             proposedSize: proposedSize,
@@ -553,11 +553,11 @@ public enum LayoutSystem {
             environment: environment,
             ignoreHiddenChildrenEntirely: false
         )
-        
+
         var size = ViewSize.zero
         size.width = renderedChildren.map(\.size.width).reduce(0, { max($0, $1) })
         size.height = renderedChildren.map(\.size.height).reduce(0, { max($0, $1) })
-        
+
         return ViewLayoutResult(
             size: size,
             childResults: renderedChildren,
@@ -565,7 +565,7 @@ public enum LayoutSystem {
                 .contains(where: \.participateInStackLayoutsWhenEmpty)
         )
     }
-    
+
     @MainActor
     static func recomputeZStackCache(
         children: [LayoutableChild],
@@ -574,10 +574,10 @@ public enum LayoutSystem {
     ) -> StackLayoutCache {
         let minimumProposedSize = ProposedViewSize(0, 0)
         let maximumProposedSize = ProposedViewSize(.infinity, .infinity)
-        
+
         var isHidden = [Bool](repeating: false, count: children.count)
         var priorities = [Double](repeating: 0, count: children.count)
-        
+
         let flexibilities = children.enumerated().map { i, child in
             let minimumResult = child.computeLayout(
                 proposedSize: minimumProposedSize,
@@ -587,16 +587,16 @@ public enum LayoutSystem {
                 proposedSize: maximumProposedSize,
                 environment: environment.with(\.allowLayoutCaching, true)
             )
-            
+
             isHidden[i] = !minimumResult.participatesInStackLayouts
             priorities[i] = minimumResult.preferences.layoutPriority
-            
+
             let widthFlexibility = maximumResult.size.width - minimumResult.size.width
             let heightFlexibility = maximumResult.size.height - minimumResult.size.height
-            
+
             return widthFlexibility + heightFlexibility
         }
-        
+
         let sortedChildren = zip(children.indices, zip(priorities.map(-), flexibilities))
             .sorted { first, second in
                 // Sort by descending priority and then by ascending flexibility
@@ -605,14 +605,14 @@ public enum LayoutSystem {
             .map { index, _ in
                 index
             }
-        
+
         var priorityGroups: [LayoutPriorityGroup] = []
         var previousPriority: Double? = nil
         var startIndex: Int?
-        
+
         for (sortedIndex, originalIndex) in sortedChildren.enumerated() {
             let priority = priorities[originalIndex]
-            
+
             if priority != previousPriority {
                 if let startIndex, let previousPriority {
                     let group = LayoutPriorityGroup(
@@ -621,12 +621,12 @@ public enum LayoutSystem {
                     )
                     priorityGroups.append(group)
                 }
-                
+
                 startIndex = sortedIndex
                 previousPriority = priority
             }
         }
-        
+
         if let startIndex, let previousPriority {
             let group = LayoutPriorityGroup(
                 children: sortedChildren[startIndex..<sortedChildren.endIndex],
@@ -634,7 +634,7 @@ public enum LayoutSystem {
             )
             priorityGroups.append(group)
         }
-        
+
         return StackLayoutCache(
             priorityGroups: priorityGroups,
             isHidden: isHidden,
@@ -644,7 +644,7 @@ public enum LayoutSystem {
             redistributeSpaceOnCommit: false
         )
     }
-    
+
     /// The main ZStack layout space allocation algorithm. Used during computeLayout.
     @MainActor
     static func computeZStackLayouts(
@@ -658,21 +658,21 @@ public enum LayoutSystem {
             repeating: .leafView(size: .zero),
             count: children.count
         )
-        
+
         for group in cache.priorityGroups {
             var childrenRemaining = group.children.count { index in
                 !cache.isHidden[index]
             }
-            
+
             for index in group.children {
                 let child = children[index]
-                
+
                 // No need to render visible children.
                 if cache.isHidden[index] {
                     if ignoreHiddenChildrenEntirely {
                         continue
                     }
-                    
+
                     // Update child in case it has just changed from visible to hidden,
                     // and to make sure that the view is still hidden (if it's not then
                     // it's a bug with either the view or the layout system).
@@ -693,20 +693,20 @@ public enum LayoutSystem {
                     renderedChildren[index].size = .zero
                     continue
                 }
-                
+
                 let childResult = child.computeLayout(
                     proposedSize: proposedSize,
                     environment: environment
                 )
-                
+
                 renderedChildren[index] = childResult
                 childrenRemaining -= 1
             }
         }
-        
+
         return renderedChildren
     }
-    
+
     @MainActor
     static func commitZStackLayout<Backend: BaseAppBackend>(
         container: Backend.Widget,
@@ -719,13 +719,13 @@ public enum LayoutSystem {
         let size = layout.size
         let alignment = environment.zStackContentAlignment
         backend.setSize(of: container, to: size.vector)
-        
+
         guard !cache.redistributeSpaceOnCommit else {
             fatalError("unreachable")
         }
-        
+
         let renderedChildren = children.map { $0.commit() }
-        
+
         var position = Position.zero
         for (index, child) in renderedChildren.enumerated() {
             // Avoid the whole iteration if the child is hidden. If there
@@ -734,7 +734,7 @@ public enum LayoutSystem {
             if !child.participatesInStackLayouts {
                 continue
             }
-            
+
             // Compute alignment
             switch alignment {
                 case .topLeading:
@@ -744,17 +744,17 @@ public enum LayoutSystem {
                     let outerX = size.width
                     let innerX = child.size.width
                     position.x = (outerX - innerX) / 2
-                    
+
                     position.y = 0
                 case .topTrailing:
                     let outerX = size.width
                     let innerX = child.size.width
                     position.x = outerX - innerX
-                    
+
                     position.y = 0
                 case .leading:
                     position.x = 0
-                    
+
                     let outerY = size.height
                     let innerY = child.size.height
                     position.y = (outerY - innerY) / 2
@@ -762,7 +762,7 @@ public enum LayoutSystem {
                     let outerX = size.width
                     let innerX = child.size.width
                     position.x = (outerX - innerX) / 2
-                    
+
                     let outerY = size.height
                     let innerY = child.size.height
                     position.y = (outerY - innerY) / 2
@@ -770,13 +770,13 @@ public enum LayoutSystem {
                     let outerX = size.width
                     let innerX = child.size.width
                     position.x = outerX - innerX
-                    
+
                     let outerY = size.height
                     let innerY = child.size.height
                     position.y = (outerY - innerY) / 2
                 case .bottomLeading:
                     position.x = 0
-                    
+
                     let outerY = size.height
                     let innerY = child.size.height
                     position.y = outerY - innerY
@@ -784,7 +784,7 @@ public enum LayoutSystem {
                     let outerX = size.width
                     let innerX = child.size.width
                     position.x = (outerX - innerX) / 2
-                    
+
                     let outerY = size.height
                     let innerY = child.size.height
                     position.y = outerY - innerY
@@ -792,7 +792,7 @@ public enum LayoutSystem {
                     let outerX = size.width
                     let innerX = child.size.width
                     position.x = outerX - innerX
-                    
+
                     let outerY = size.height
                     let innerY = child.size.height
                     position.y = outerY - innerY
@@ -800,12 +800,12 @@ public enum LayoutSystem {
                     let outerX = size.width
                     let innerX = child.size.width
                     position.x = (outerX - innerX) / 2
-                    
+
                     let outerY = size.height
                     let innerY = child.size.height
                     position.y = (outerY - innerY) / 2
             }
-            
+
             backend.setPosition(ofChildAt: index, in: container, to: position.vector)
         }
     }

--- a/Sources/SwiftCrossUI/Layout/LayoutSystem.swift
+++ b/Sources/SwiftCrossUI/Layout/LayoutSystem.swift
@@ -495,7 +495,12 @@ public enum LayoutSystem {
         inheritStackLayoutParticipation: Bool = false
     ) -> ViewLayoutResult {
         let specialSizes: [Double?] = [nil, .infinity]
-        if children.count <= 1 || (specialSizes.contains(proposedSize.width) && specialSizes.contains(proposedSize.height)) {
+        if children.count <= 1
+            || (
+                specialSizes.contains(proposedSize.width)
+                    && specialSizes.contains(proposedSize.height)
+            )
+        {
             var stackWidth: Double = 0
             var stackHeight: Double = 0
             var results: [ViewLayoutResult] = []
@@ -568,22 +573,19 @@ public enum LayoutSystem {
         environment: EnvironmentValues
     ) -> StackLayoutCache {
         let minimumProposedSize = ProposedViewSize(0, 0)
-        let maximumProposedSize = ProposedViewSize(.infinity, .infinity)
 
-        var priorities = [Double](repeating: 0, count: children.count)
-
-        for (i, child) in children.enumerated() {
+        let priorities = children.map { child in
             let minimumResult = child.computeLayout(
                 proposedSize: minimumProposedSize,
                 environment: environment.with(\.allowLayoutCaching, true)
             )
 
-            priorities[i] = minimumResult.preferences.layoutPriority
+            return minimumResult.preferences.layoutPriority
         }
 
         let sortedChildren = zip(children.indices, priorities.map(-))
             .sorted { first, second in
-                // Sort by descending priority and then by ascending flexibility
+                // Sort by descending priority
                 first.1 <= second.1
             }
             .map { index, _ in
@@ -641,12 +643,12 @@ public enum LayoutSystem {
             repeating: .leafView(size: .zero),
             count: children.count
         )
-        
+
         var currentProposedSize = proposedSize
 
         for group in cache.priorityGroups {
             var maxSize: ProposedViewSize = .zero
-            
+
             for index in group.children {
                 let child = children[index]
 
@@ -654,13 +656,13 @@ public enum LayoutSystem {
                     proposedSize: currentProposedSize,
                     environment: environment
                 )
-                
+
                 if let currentMaxWidth = maxSize.width {
                     maxSize.width = max(childResult.size.width, currentMaxWidth)
                 } else {
                     maxSize.width = childResult.size.width
                 }
-                
+
                 if let currentMaxHeight = maxSize.height {
                     maxSize.height = max(childResult.size.height, currentMaxHeight)
                 } else {
@@ -669,7 +671,7 @@ public enum LayoutSystem {
 
                 renderedChildren[index] = childResult
             }
-            
+
             currentProposedSize = maxSize
         }
 
@@ -697,7 +699,7 @@ public enum LayoutSystem {
                 environment: environment
             )
         }
-        
+
         let renderedChildren = children.map { $0.commit() }
 
         for (index, child) in renderedChildren.enumerated() {
@@ -709,7 +711,7 @@ public enum LayoutSystem {
             }
             // Compute alignment
             let position = alignment.position(ofChild: child.size.vector, in: size.vector)
-            
+
             backend.setPosition(ofChildAt: index, in: container, to: position)
         }
     }

--- a/Sources/SwiftCrossUI/Layout/LayoutSystem.swift
+++ b/Sources/SwiftCrossUI/Layout/LayoutSystem.swift
@@ -116,6 +116,17 @@ public enum LayoutSystem {
         backend: Backend,
         inheritStackLayoutParticipation: Bool = false
     ) -> ViewLayoutResult {
+        guard !environment.usesZStackLayout else {
+            return computeZStackLayout(
+                container: container,
+                children: children,
+                cache: &cache,
+                proposedSize: proposedSize,
+                environment: environment,
+                backend: backend
+            )
+        }
+        
         let spacing = environment.layoutSpacing
         let orientation = environment.layoutOrientation
         let perpendicularOrientation = orientation.perpendicular
@@ -330,6 +341,19 @@ public enum LayoutSystem {
         environment: EnvironmentValues,
         backend: Backend
     ) {
+        guard !environment.usesZStackLayout else {
+            commitZStackLayout(
+                container: container,
+                children: children,
+                cache: &cache,
+                layout: layout,
+                environment: environment,
+                backend: backend
+            )
+            
+            return
+        }
+        
         let size = layout.size
         backend.setSize(of: container, to: size.vector)
 
@@ -458,5 +482,331 @@ public enum LayoutSystem {
         }
 
         return renderedChildren
+    }
+    
+    @MainActor
+    static func computeZStackLayout<Backend: BaseAppBackend>(
+        container: Backend.Widget,
+        children: [LayoutableChild],
+        cache: inout StackLayoutCache,
+        proposedSize: ProposedViewSize,
+        environment: EnvironmentValues,
+        backend: Backend,
+        inheritStackLayoutParticipation: Bool = false
+    ) -> ViewLayoutResult {
+        if children.count == 1 {
+            var maxWidth: Double = 0
+            var maxHeight: Double = 0
+            var results: [ViewLayoutResult] = []
+            for child in children {
+                let result = child.computeLayout(
+                    proposedSize: proposedSize,
+                    environment: environment
+                )
+                maxWidth = max(maxWidth, result.size.width)
+                maxHeight = max(maxHeight, result.size.height)
+                results.append(result)
+            }
+            
+            let size = ViewSize(maxWidth, maxHeight)
+            
+            // In this case, flexibility and layout priority don't matter. We set
+            // the grouping to the trivial grouping so that commitStackLayout
+            // effectively ignores flexibility.
+            let group = LayoutPriorityGroup(
+                children: Array(children.indices)[...],
+                priority: 0
+            )
+            cache = StackLayoutCache(
+                priorityGroups: [group],
+                isHidden: results.map(\.participatesInStackLayouts).map(!),
+                // TODO(stackotter): How does SwiftUI handle space reservation during
+                //   relayouts? I feel like it probably doesn't use minimum lengths if
+                //   it didn't already have to during the initial layout pass because
+                //   the alternative would be expensive, but that approach would also
+                //   be a bit inconsistent
+                totalSpacing: 0,
+                totalReservedSpace: 0,
+                minimumLengths: [Double](repeating: 0, count: children.count),
+                redistributeSpaceOnCommit: false
+            )
+            
+            return ViewLayoutResult(
+                size: size,
+                childResults: results,
+                participateInStackLayoutsWhenEmpty: results
+                    .contains(where: \.participateInStackLayoutsWhenEmpty),
+                preferencesOverlay: nil
+            )
+        }
+        
+        cache = recomputeZStackCache(
+            children: children,
+            proposedSize: proposedSize,
+            environment: environment
+        )
+        
+        let renderedChildren = computeZStackLayouts(
+            of: children,
+            proposedSize: proposedSize,
+            cache: cache,
+            environment: environment,
+            ignoreHiddenChildrenEntirely: false
+        )
+        
+        var size = ViewSize.zero
+        size.width = renderedChildren.map(\.size.width).reduce(0, { max($0, $1) })
+        size.height = renderedChildren.map(\.size.height).reduce(0, { max($0, $1) })
+        
+        return ViewLayoutResult(
+            size: size,
+            childResults: renderedChildren,
+            participateInStackLayoutsWhenEmpty: renderedChildren
+                .contains(where: \.participateInStackLayoutsWhenEmpty)
+        )
+    }
+    
+    @MainActor
+    static func recomputeZStackCache(
+        children: [LayoutableChild],
+        proposedSize: ProposedViewSize,
+        environment: EnvironmentValues
+    ) -> StackLayoutCache {
+        let minimumProposedSize = ProposedViewSize(0, 0)
+        let maximumProposedSize = ProposedViewSize(.infinity, .infinity)
+        
+        var isHidden = [Bool](repeating: false, count: children.count)
+        var priorities = [Double](repeating: 0, count: children.count)
+        
+        let flexibilities = children.enumerated().map { i, child in
+            let minimumResult = child.computeLayout(
+                proposedSize: minimumProposedSize,
+                environment: environment.with(\.allowLayoutCaching, true)
+            )
+            let maximumResult = child.computeLayout(
+                proposedSize: maximumProposedSize,
+                environment: environment.with(\.allowLayoutCaching, true)
+            )
+            
+            isHidden[i] = !minimumResult.participatesInStackLayouts
+            priorities[i] = minimumResult.preferences.layoutPriority
+            
+            let widthFlexibility = maximumResult.size.width - minimumResult.size.width
+            let heightFlexibility = maximumResult.size.height - minimumResult.size.height
+            
+            return widthFlexibility + heightFlexibility
+        }
+        
+        let sortedChildren = zip(children.indices, zip(priorities.map(-), flexibilities))
+            .sorted { first, second in
+                // Sort by descending priority and then by ascending flexibility
+                first.1 <= second.1
+            }
+            .map { index, _ in
+                index
+            }
+        
+        var priorityGroups: [LayoutPriorityGroup] = []
+        var previousPriority: Double? = nil
+        var startIndex: Int?
+        
+        for (sortedIndex, originalIndex) in sortedChildren.enumerated() {
+            let priority = priorities[originalIndex]
+            
+            if priority != previousPriority {
+                if let startIndex, let previousPriority {
+                    let group = LayoutPriorityGroup(
+                        children: sortedChildren[startIndex..<sortedIndex],
+                        priority: previousPriority
+                    )
+                    priorityGroups.append(group)
+                }
+                
+                startIndex = sortedIndex
+                previousPriority = priority
+            }
+        }
+        
+        if let startIndex, let previousPriority {
+            let group = LayoutPriorityGroup(
+                children: sortedChildren[startIndex..<sortedChildren.endIndex],
+                priority: previousPriority
+            )
+            priorityGroups.append(group)
+        }
+        
+        return StackLayoutCache(
+            priorityGroups: priorityGroups,
+            isHidden: isHidden,
+            totalSpacing: 0,
+            totalReservedSpace: 0,
+            minimumLengths: [],
+            redistributeSpaceOnCommit: false
+        )
+    }
+    
+    /// The main ZStack layout space allocation algorithm. Used during computeLayout.
+    @MainActor
+    static func computeZStackLayouts(
+        of children: [LayoutableChild],
+        proposedSize: ProposedViewSize,
+        cache: StackLayoutCache,
+        environment: EnvironmentValues,
+        ignoreHiddenChildrenEntirely: Bool
+    ) -> [ViewLayoutResult] {
+        var renderedChildren = [ViewLayoutResult](
+            repeating: .leafView(size: .zero),
+            count: children.count
+        )
+        
+        for group in cache.priorityGroups {
+            var childrenRemaining = group.children.count { index in
+                !cache.isHidden[index]
+            }
+            
+            for index in group.children {
+                let child = children[index]
+                
+                // No need to render visible children.
+                if cache.isHidden[index] {
+                    if ignoreHiddenChildrenEntirely {
+                        continue
+                    }
+                    
+                    // Update child in case it has just changed from visible to hidden,
+                    // and to make sure that the view is still hidden (if it's not then
+                    // it's a bug with either the view or the layout system).
+                    let result = child.computeLayout(
+                        proposedSize: .zero,
+                        environment: environment
+                    )
+                    if result.participatesInStackLayouts {
+                        logger.warning(
+                            "hidden view became visible on second update; layout may break",
+                            metadata: [
+                                "view": "\(child.tag ?? "<unknown type>")"
+                            ]
+                        )
+                    }
+                    renderedChildren[index] = result
+                    renderedChildren[index].participateInStackLayoutsWhenEmpty = false
+                    renderedChildren[index].size = .zero
+                    continue
+                }
+                
+                let childResult = child.computeLayout(
+                    proposedSize: proposedSize,
+                    environment: environment
+                )
+                
+                renderedChildren[index] = childResult
+                childrenRemaining -= 1
+            }
+        }
+        
+        return renderedChildren
+    }
+    
+    @MainActor
+    static func commitZStackLayout<Backend: BaseAppBackend>(
+        container: Backend.Widget,
+        children: [LayoutableChild],
+        cache: inout StackLayoutCache,
+        layout: ViewLayoutResult,
+        environment: EnvironmentValues,
+        backend: Backend
+    ) {
+        let size = layout.size
+        let alignment = environment.zStackContentAlignment
+        backend.setSize(of: container, to: size.vector)
+        
+        guard !cache.redistributeSpaceOnCommit else {
+            fatalError("unreachable")
+        }
+        
+        let renderedChildren = children.map { $0.commit() }
+        
+        var position = Position.zero
+        for (index, child) in renderedChildren.enumerated() {
+            // Avoid the whole iteration if the child is hidden. If there
+            // are weird positioning issues for views that do strange things
+            // then this could be the cause.
+            if !child.participatesInStackLayouts {
+                continue
+            }
+            
+            // Compute alignment
+            switch alignment {
+                case .topLeading:
+                    position.x = 0
+                    position.y = 0
+                case .top:
+                    let outerX = size.width
+                    let innerX = child.size.width
+                    position.x = (outerX - innerX) / 2
+                    
+                    position.y = 0
+                case .topTrailing:
+                    let outerX = size.width
+                    let innerX = child.size.width
+                    position.x = outerX - innerX
+                    
+                    position.y = 0
+                case .leading:
+                    position.x = 0
+                    
+                    let outerY = size.height
+                    let innerY = child.size.height
+                    position.y = (outerY - innerY) / 2
+                case .center:
+                    let outerX = size.width
+                    let innerX = child.size.width
+                    position.x = (outerX - innerX) / 2
+                    
+                    let outerY = size.height
+                    let innerY = child.size.height
+                    position.y = (outerY - innerY) / 2
+                case .trailing:
+                    let outerX = size.width
+                    let innerX = child.size.width
+                    position.x = outerX - innerX
+                    
+                    let outerY = size.height
+                    let innerY = child.size.height
+                    position.y = (outerY - innerY) / 2
+                case .bottomLeading:
+                    position.x = 0
+                    
+                    let outerY = size.height
+                    let innerY = child.size.height
+                    position.y = outerY - innerY
+                case .bottom:
+                    let outerX = size.width
+                    let innerX = child.size.width
+                    position.x = (outerX - innerX) / 2
+                    
+                    let outerY = size.height
+                    let innerY = child.size.height
+                    position.y = outerY - innerY
+                case .bottomTrailing:
+                    let outerX = size.width
+                    let innerX = child.size.width
+                    position.x = outerX - innerX
+                    
+                    let outerY = size.height
+                    let innerY = child.size.height
+                    position.y = outerY - innerY
+                default:
+                    let outerX = size.width
+                    let innerX = child.size.width
+                    position.x = (outerX - innerX) / 2
+                    
+                    let outerY = size.height
+                    let innerY = child.size.height
+                    position.y = (outerY - innerY) / 2
+            }
+            
+            backend.setPosition(ofChildAt: index, in: container, to: position.vector)
+        }
     }
 }

--- a/Sources/SwiftCrossUI/Views/HStack.swift
+++ b/Sources/SwiftCrossUI/Views/HStack.swift
@@ -57,7 +57,8 @@ public struct HStack<Content: View>: View {
             environment: environment
                 .with(\.layoutOrientation, .horizontal)
                 .with(\.layoutAlignment, alignment.asStackAlignment)
-                .with(\.layoutSpacing, spacing),
+                .with(\.layoutSpacing, spacing)
+                .with(\.usesZStackLayout, false),
             backend: backend
         )
         (children as? TupleViewChildren)?.stackLayoutCache = cache
@@ -80,7 +81,8 @@ public struct HStack<Content: View>: View {
             environment: environment
                 .with(\.layoutOrientation, .horizontal)
                 .with(\.layoutAlignment, alignment.asStackAlignment)
-                .with(\.layoutSpacing, spacing),
+                .with(\.layoutSpacing, spacing)
+                .with(\.usesZStackLayout, false),
             backend: backend
         )
         (children as? TupleViewChildren)?.stackLayoutCache = cache

--- a/Sources/SwiftCrossUI/Views/Spacer.swift
+++ b/Sources/SwiftCrossUI/Views/Spacer.swift
@@ -27,11 +27,18 @@ public struct Spacer: ElementaryView, View {
         backend: Backend
     ) -> ViewLayoutResult {
         var size = ViewSize.zero
-        let proposedLength = proposedSize[component: environment.layoutOrientation]
-        size[component: environment.layoutOrientation] = max(
-            Double(minLength ?? 0),
-            proposedLength ?? Self.idealLength
-        )
+
+        if environment.usesZStackLayout {
+            size = proposedSize.replacingUnspecifiedDimensions(
+                by: ViewSize(Self.idealLength, Self.idealLength)
+            )
+        } else {
+            let proposedLength = proposedSize[component: environment.layoutOrientation]
+            size[component: environment.layoutOrientation] = max(
+                Double(minLength ?? 0),
+                proposedLength ?? Self.idealLength
+            )
+        }
 
         return ViewLayoutResult(
             size: size,

--- a/Sources/SwiftCrossUI/Views/VStack.swift
+++ b/Sources/SwiftCrossUI/Views/VStack.swift
@@ -80,7 +80,8 @@ public struct VStack<Content: View>: View {
             environment: environment
                 .with(\.layoutOrientation, .vertical)
                 .with(\.layoutAlignment, alignment.asStackAlignment)
-                .with(\.layoutSpacing, spacing),
+                .with(\.layoutSpacing, spacing)
+                .with(\.usesZStackLayout, false),
             backend: backend
         )
         (children as? TupleViewChildren)?.stackLayoutCache = cache
@@ -103,7 +104,8 @@ public struct VStack<Content: View>: View {
             environment: environment
                 .with(\.layoutOrientation, .vertical)
                 .with(\.layoutAlignment, alignment.asStackAlignment)
-                .with(\.layoutSpacing, spacing),
+                .with(\.layoutSpacing, spacing)
+                .with(\.usesZStackLayout, false),
             backend: backend
         )
         (children as? TupleViewChildren)?.stackLayoutCache = cache

--- a/Sources/SwiftCrossUI/Views/View.swift
+++ b/Sources/SwiftCrossUI/Views/View.swift
@@ -201,8 +201,7 @@ extension View {
         environment: EnvironmentValues,
         backend: Backend
     ) -> ViewLayoutResult {
-        let vStack = VStack(content: body)
-        return vStack.computeLayout(
+        return body.computeLayout(
             widget,
             children: children,
             proposedSize: proposedSize,
@@ -234,8 +233,7 @@ extension View {
         environment: EnvironmentValues,
         backend: Backend
     ) {
-        let vStack = VStack(content: body)
-        return vStack.commit(
+        return body.commit(
             widget,
             children: children,
             layout: layout,

--- a/Sources/SwiftCrossUI/Views/ZStack.swift
+++ b/Sources/SwiftCrossUI/Views/ZStack.swift
@@ -61,7 +61,8 @@ public struct ZStack<Content: View>: View {
             proposedSize: proposedSize,
             environment: environment
                 .with(\.usesZStackLayout, true)
-                .with(\.zStackContentAlignment, alignment),
+                .with(\.zStackContentAlignment, alignment)
+                .with(\.layoutOrientation, .vertical),
             backend: backend
         )
         (children as? TupleViewChildren)?.stackLayoutCache = cache
@@ -83,7 +84,8 @@ public struct ZStack<Content: View>: View {
             layout: layout,
             environment: environment
                 .with(\.usesZStackLayout, true)
-                .with(\.zStackContentAlignment, alignment),
+                .with(\.zStackContentAlignment, alignment)
+                .with(\.layoutOrientation, .vertical),
             backend: backend
         )
         (children as? TupleViewChildren)?.stackLayoutCache = cache

--- a/Sources/SwiftCrossUI/Views/ZStack.swift
+++ b/Sources/SwiftCrossUI/Views/ZStack.swift
@@ -52,7 +52,7 @@ public struct ZStack<Content: View>: View {
                 ]
             )
         }
-        
+
         var cache = (children as? TupleViewChildren)?.stackLayoutCache ?? StackLayoutCache.initial
         let result = LayoutSystem.computeZStackLayout(
             container: widget,

--- a/Sources/SwiftCrossUI/Views/ZStack.swift
+++ b/Sources/SwiftCrossUI/Views/ZStack.swift
@@ -43,19 +43,6 @@ public struct ZStack<Content: View>: View {
         environment: EnvironmentValues,
         backend: Backend
     ) -> ViewLayoutResult {
-        let childResults = layoutableChildren(backend: backend, children: children)
-            .map { child in
-                child.computeLayout(
-                    proposedSize: proposedSize,
-                    environment: environment
-                )
-            }
-
-        let size = ViewSize(
-            childResults.map(\.size.width).max() ?? 0,
-            childResults.map(\.size.height).max() ?? 0
-        )
-
         if !(children is TupleViewChildren || children is EmptyViewChildren) {
             logger.warning(
                 "ZStack will not function correctly with non-TupleView content",
@@ -65,17 +52,20 @@ public struct ZStack<Content: View>: View {
                 ]
             )
         }
-
-        (children as? TupleViewChildren)?.stackLayoutCache = StackLayoutCache(
-            priorityGroups: [],
-            isHidden: [],
-            totalSpacing: 0,
-            totalReservedSpace: 0,
-            minimumLengths: [],
-            redistributeSpaceOnCommit: proposedSize.width == nil || proposedSize.height == nil
+        
+        var cache = (children as? TupleViewChildren)?.stackLayoutCache ?? StackLayoutCache.initial
+        let result = LayoutSystem.computeZStackLayout(
+            container: widget,
+            children: layoutableChildren(backend: backend, children: children),
+            cache: &cache,
+            proposedSize: proposedSize,
+            environment: environment
+                .with(\.usesZStackLayout, true)
+                .with(\.zStackContentAlignment, alignment),
+            backend: backend
         )
-
-        return ViewLayoutResult(size: size, childResults: childResults)
+        (children as? TupleViewChildren)?.stackLayoutCache = cache
+        return result
     }
 
     public func commit<Backend: BaseAppBackend>(
@@ -85,31 +75,17 @@ public struct ZStack<Content: View>: View {
         environment: EnvironmentValues,
         backend: Backend
     ) {
-        let cache = (children as? TupleViewChildren)?.stackLayoutCache ?? StackLayoutCache.initial
-        let children = layoutableChildren(backend: backend, children: children)
-
-        if cache.redistributeSpaceOnCommit {
-            for child in children {
-                _ = child.computeLayout(
-                    proposedSize: ProposedViewSize(layout.size),
-                    environment: environment
-                )
-            }
-        }
-
-        let size = layout.size
-        let layoutResults = children.map { child in
-            child.commit()
-        }
-
-        for (i, layoutResult) in layoutResults.enumerated() {
-            let position = alignment.position(
-                ofChild: layoutResult.size.vector,
-                in: size.vector
-            )
-            backend.setPosition(ofChildAt: i, in: widget, to: position)
-        }
-
-        backend.setSize(of: widget, to: size.vector)
+        var cache = (children as? TupleViewChildren)?.stackLayoutCache ?? StackLayoutCache.initial
+        LayoutSystem.commitZStackLayout(
+            container: widget,
+            children: layoutableChildren(backend: backend, children: children),
+            cache: &cache,
+            layout: layout,
+            environment: environment
+                .with(\.usesZStackLayout, true)
+                .with(\.zStackContentAlignment, alignment),
+            backend: backend
+        )
+        (children as? TupleViewChildren)?.stackLayoutCache = cache
     }
 }

--- a/Sources/UIKitBackend/UIKitBackend+Sheet.swift
+++ b/Sources/UIKitBackend/UIKitBackend+Sheet.swift
@@ -67,28 +67,28 @@ extension UIKitBackend {
             // in my Mac's color space).
             switch environment.colorScheme {
                 case .light:
-                defaultColor = UIColor(
-                    red: 1,
-                    green: 1,
-                    blue: 1,
-                    alpha: 1
-                )
+                    defaultColor = UIColor(
+                        red: 1,
+                        green: 1,
+                        blue: 1,
+                        alpha: 1
+                    )
                 case .dark:
-                #if os(tvOS)
-                    defaultColor = UIColor(
-                        red: 15 / 255,
-                        green: 15 / 255,
-                        blue: 15 / 255,
-                        alpha: 1
-                    )
-                #else
-                    defaultColor = UIColor(
-                        red: 28 / 255,
-                        green: 28 / 255,
-                        blue: 30 / 255,
-                        alpha: 1
-                    )
-                #endif
+                    #if os(tvOS)
+                        defaultColor = UIColor(
+                            red: 15 / 255,
+                            green: 15 / 255,
+                            blue: 15 / 255,
+                            alpha: 1
+                        )
+                    #else
+                        defaultColor = UIColor(
+                            red: 28 / 255,
+                            green: 28 / 255,
+                            blue: 30 / 255,
+                            alpha: 1
+                        )
+                    #endif
             }
         #endif
         sheet.view.backgroundColor = backgroundColor?.uiColor ?? defaultColor

--- a/Tests/SwiftCrossUITests/StackContextRendersDifferently.swift
+++ b/Tests/SwiftCrossUITests/StackContextRendersDifferently.swift
@@ -7,9 +7,9 @@ import DummyBackend
 struct StackContextRendersDifferently {
     struct TestView: View {
         // The view body contains the same text two times, cause that is a simple
-        // way to check the expected behaviour. The bounds are expected to be 1:1
-        // so for HStack the y position needs to be the same, x for VStack
-        // and both for ZStack.
+        // way to check the expected behaviour.
+        // The children are expected to be identical, so for HStack the y position
+        // needs to be the same, x for VStack and both for ZStack.
         var body: some View {
             Text("Test")
             Text("Test")
@@ -89,16 +89,13 @@ struct StackContextRendersDifferently {
             return
         }
 
-        #expect(container.children.count == 2)
-
-        guard
-            container.children.count == 2,
-            let (_, firstPosition) = container.children.first,
-            let (_, secondPosition) = container.children.last
-        else {
-            Issue.record("Unexpectedly failed to extract child positions.")
+        guard container.children.count == 2 else {
+            Issue.record("Expected there to be two children in the container.")
             return
         }
+        
+        let (_, firstPosition) = container.children[0]
+        let (_, secondPosition) = container.children[1]
 
         #expect(check(firstPosition, secondPosition))
     }

--- a/Tests/SwiftCrossUITests/StackContextRendersDifferently.swift
+++ b/Tests/SwiftCrossUITests/StackContextRendersDifferently.swift
@@ -1,0 +1,195 @@
+import Testing
+import DummyBackend
+@testable @_spi(Backends) import SwiftCrossUI
+
+@MainActor
+@Suite("View renders differently depending on the surrounding stack context")
+struct StackContextRendersDifferently {
+    struct TestView: View {
+        // The view body contains the same text two times, cause that is a simple
+        // way to check the expected behaviour. The bounds are expected to be 1:1
+        // so for HStack the y position needs to be the same, x for VStack
+        // and both for ZStack.
+        var body: some View {
+            Text("Test")
+            Text("Test")
+        }
+    }
+    
+    @Test func testVStack() {
+        let backend = DummyBackend()
+        let window = backend.createWindow(withDefaultSize: nil, id: "window")
+        let environment = EnvironmentValues(backend: backend).with(\.window, window)
+        
+        let view = VStack {
+            TestView()
+        }
+        
+        let node = ViewGraphNode(for: view, backend: backend, environment: environment)
+        
+        _ = node.computeLayout(
+            proposedSize: .unspecified,
+            environment: environment
+        )
+        
+        _ = node.commit()
+        
+        let widget = node.widget
+        
+        var lastParent: DummyBackend.Widget? = nil
+        var children = widget.getChildren()
+        
+        while children.count != 2 {
+            guard let first = children.first else {
+                Issue.record("Unexpectedly didn't find children.")
+                return
+            }
+            lastParent = first
+            children = first.getChildren()
+        }
+        
+        guard
+            let _ = children.first as? DummyBackend.TextView,
+            let _ = children.last as? DummyBackend.TextView
+        else {
+            Issue.record("Unexpectedly didn't find text views.")
+            return
+        }
+        
+        guard let container = lastParent as? DummyBackend.Container else {
+            Issue.record("Parent of text views unexpectedly wasn't a container.")
+            return
+        }
+        
+        #expect(container.children.count == 2)
+        
+        guard
+            container.children.count == 2,
+            let (_, firstPosition) = container.children.first,
+            let (_, secondPosition) = container.children.last
+        else {
+            Issue.record("Unexpectedly failed to extract child positions.")
+            return
+        }
+        
+        #expect(firstPosition.x == secondPosition.x)
+    }
+    
+    @Test func testHStack() {
+        let backend = DummyBackend()
+        let window = backend.createWindow(withDefaultSize: nil, id: "window")
+        let environment = EnvironmentValues(backend: backend).with(\.window, window)
+        
+        let view = HStack {
+            TestView()
+        }
+        
+        let node = ViewGraphNode(for: view, backend: backend, environment: environment)
+        
+        _ = node.computeLayout(
+            proposedSize: .unspecified,
+            environment: environment
+        )
+        
+        _ = node.commit()
+        
+        let widget = node.widget
+        
+        var lastParent: DummyBackend.Widget? = nil
+        var children = widget.getChildren()
+        
+        while children.count != 2 {
+            guard let first = children.first else {
+                Issue.record("Unexpectedly didn't find children.")
+                return
+            }
+            lastParent = first
+            children = first.getChildren()
+        }
+        
+        guard
+            let _ = children.first as? DummyBackend.TextView,
+            let _ = children.last as? DummyBackend.TextView
+                else {
+            Issue.record("Unexpectedly didn't find text views.")
+            return
+        }
+        
+        guard let container = lastParent as? DummyBackend.Container else {
+            Issue.record("Parent of text views unexpectedly wasn't a container.")
+            return
+        }
+        
+        #expect(container.children.count == 2)
+        
+        guard
+            container.children.count == 2,
+            let (_, firstPosition) = container.children.first,
+            let (_, secondPosition) = container.children.last
+                else {
+            Issue.record("Unexpectedly failed to extract child positions.")
+            return
+        }
+        
+        #expect(firstPosition.y == secondPosition.y)
+    }
+    
+    @Test func testZStack() {
+        let backend = DummyBackend()
+        let window = backend.createWindow(withDefaultSize: nil, id: "window")
+        let environment = EnvironmentValues(backend: backend).with(\.window, window)
+        
+        let view = ZStack {
+            TestView()
+        }
+        
+        let node = ViewGraphNode(for: view, backend: backend, environment: environment)
+        
+        _ = node.computeLayout(
+            proposedSize: .unspecified,
+            environment: environment
+        )
+        
+        _ = node.commit()
+        
+        let widget = node.widget
+        
+        var lastParent: DummyBackend.Widget? = nil
+        var children = widget.getChildren()
+        
+        while children.count != 2 {
+            guard let first = children.first else {
+                Issue.record("Unexpectedly didn't find children.")
+                return
+            }
+            lastParent = first
+            children = first.getChildren()
+        }
+        
+        guard
+            let _ = children.first as? DummyBackend.TextView,
+            let _ = children.last as? DummyBackend.TextView
+                else {
+            Issue.record("Unexpectedly didn't find text views.")
+            return
+        }
+        
+        guard let container = lastParent as? DummyBackend.Container else {
+            Issue.record("Parent of text views unexpectedly wasn't a container.")
+            return
+        }
+        
+        #expect(container.children.count == 2)
+        
+        guard
+            container.children.count == 2,
+            let (_, firstPosition) = container.children.first,
+            let (_, secondPosition) = container.children.last
+                else {
+            Issue.record("Unexpectedly failed to extract child positions.")
+            return
+        }
+        
+        #expect(firstPosition == secondPosition)
+    }
+}

--- a/Tests/SwiftCrossUITests/StackContextRendersDifferently.swift
+++ b/Tests/SwiftCrossUITests/StackContextRendersDifferently.swift
@@ -17,131 +17,41 @@ struct StackContextRendersDifferently {
     }
 
     @Test func testVStack() {
-        let backend = DummyBackend()
-        let window = backend.createWindow(withDefaultSize: nil, id: "window")
-        let environment = EnvironmentValues(backend: backend).with(\.window, window)
-
-        let view = VStack {
-            TestView()
-        }
-
-        let node = ViewGraphNode(for: view, backend: backend, environment: environment)
-
-        _ = node.computeLayout(
-            proposedSize: .unspecified,
-            environment: environment
-        )
-
-        _ = node.commit()
-
-        let widget = node.widget
-
-        var lastParent: DummyBackend.Widget? = nil
-        var children = widget.getChildren()
-
-        while children.count != 2 {
-            guard let first = children.first else {
-                Issue.record("Unexpectedly didn't find children.")
-                return
+        stackTest(
+            view: VStack { TestView() },
+            check: { firstPosition, secondPosition in
+                firstPosition.y != secondPosition.y &&
+                    firstPosition.x == secondPosition.x
             }
-            lastParent = first
-            children = first.getChildren()
-        }
-
-        guard
-            let _ = children.first as? DummyBackend.TextView,
-            let _ = children.last as? DummyBackend.TextView
-        else {
-            Issue.record("Unexpectedly didn't find text views.")
-            return
-        }
-
-        guard let container = lastParent as? DummyBackend.Container else {
-            Issue.record("Parent of text views unexpectedly wasn't a container.")
-            return
-        }
-
-        #expect(container.children.count == 2)
-
-        guard
-            container.children.count == 2,
-            let (_, firstPosition) = container.children.first,
-            let (_, secondPosition) = container.children.last
-        else {
-            Issue.record("Unexpectedly failed to extract child positions.")
-            return
-        }
-
-        #expect(firstPosition.x == secondPosition.x)
+        )
     }
 
     @Test func testHStack() {
-        let backend = DummyBackend()
-        let window = backend.createWindow(withDefaultSize: nil, id: "window")
-        let environment = EnvironmentValues(backend: backend).with(\.window, window)
-
-        let view = HStack {
-            TestView()
-        }
-
-        let node = ViewGraphNode(for: view, backend: backend, environment: environment)
-
-        _ = node.computeLayout(
-            proposedSize: .unspecified,
-            environment: environment
-        )
-
-        _ = node.commit()
-
-        let widget = node.widget
-
-        var lastParent: DummyBackend.Widget? = nil
-        var children = widget.getChildren()
-
-        while children.count != 2 {
-            guard let first = children.first else {
-                Issue.record("Unexpectedly didn't find children.")
-                return
+        stackTest(
+            view: HStack { TestView() },
+            check: { firstPosition, secondPosition in
+                firstPosition.y == secondPosition.y &&
+                    firstPosition.x != secondPosition.x
             }
-            lastParent = first
-            children = first.getChildren()
-        }
-
-        guard
-            let _ = children.first as? DummyBackend.TextView,
-            let _ = children.last as? DummyBackend.TextView
-        else {
-            Issue.record("Unexpectedly didn't find text views.")
-            return
-        }
-
-        guard let container = lastParent as? DummyBackend.Container else {
-            Issue.record("Parent of text views unexpectedly wasn't a container.")
-            return
-        }
-
-        #expect(container.children.count == 2)
-
-        guard
-            container.children.count == 2,
-            let (_, firstPosition) = container.children.first,
-            let (_, secondPosition) = container.children.last
-        else {
-            Issue.record("Unexpectedly failed to extract child positions.")
-            return
-        }
-
-        #expect(firstPosition.y == secondPosition.y)
+        )
     }
 
-    @Test func testZStack() {
+    @Test(.disabled{ true }) func testZStack() {
+        stackTest(
+            view: ZStack { TestView() },
+            check: { firstPosition, secondPosition in
+                firstPosition == secondPosition
+            }
+        )
+    }
+
+    func stackTest<V: View>(
+        view: V,
+        check: (SIMD2<Int>, SIMD2<Int>) -> Bool
+    ) {
         let backend = DummyBackend()
         let window = backend.createWindow(withDefaultSize: nil, id: "window")
         let environment = EnvironmentValues(backend: backend).with(\.window, window)
-
-        let view = ZStack {
-            TestView()
-        }
 
         let node = ViewGraphNode(for: view, backend: backend, environment: environment)
 
@@ -190,6 +100,6 @@ struct StackContextRendersDifferently {
             return
         }
 
-        #expect(firstPosition == secondPosition)
+        #expect(check(firstPosition, secondPosition))
     }
 }

--- a/Tests/SwiftCrossUITests/StackContextRendersDifferently.swift
+++ b/Tests/SwiftCrossUITests/StackContextRendersDifferently.swift
@@ -93,7 +93,7 @@ struct StackContextRendersDifferently {
             Issue.record("Expected there to be two children in the container.")
             return
         }
-        
+
         let (_, firstPosition) = container.children[0]
         let (_, secondPosition) = container.children[1]
 

--- a/Tests/SwiftCrossUITests/StackContextRendersDifferently.swift
+++ b/Tests/SwiftCrossUITests/StackContextRendersDifferently.swift
@@ -36,7 +36,7 @@ struct StackContextRendersDifferently {
         )
     }
 
-    @Test(.disabled{ true }) func testZStack() {
+    @Test func testZStack() {
         stackTest(
             view: ZStack { TestView() },
             check: { firstPosition, secondPosition in

--- a/Tests/SwiftCrossUITests/StackContextRendersDifferently.swift
+++ b/Tests/SwiftCrossUITests/StackContextRendersDifferently.swift
@@ -15,30 +15,30 @@ struct StackContextRendersDifferently {
             Text("Test")
         }
     }
-    
+
     @Test func testVStack() {
         let backend = DummyBackend()
         let window = backend.createWindow(withDefaultSize: nil, id: "window")
         let environment = EnvironmentValues(backend: backend).with(\.window, window)
-        
+
         let view = VStack {
             TestView()
         }
-        
+
         let node = ViewGraphNode(for: view, backend: backend, environment: environment)
-        
+
         _ = node.computeLayout(
             proposedSize: .unspecified,
             environment: environment
         )
-        
+
         _ = node.commit()
-        
+
         let widget = node.widget
-        
+
         var lastParent: DummyBackend.Widget? = nil
         var children = widget.getChildren()
-        
+
         while children.count != 2 {
             guard let first = children.first else {
                 Issue.record("Unexpectedly didn't find children.")
@@ -47,7 +47,7 @@ struct StackContextRendersDifferently {
             lastParent = first
             children = first.getChildren()
         }
-        
+
         guard
             let _ = children.first as? DummyBackend.TextView,
             let _ = children.last as? DummyBackend.TextView
@@ -55,14 +55,14 @@ struct StackContextRendersDifferently {
             Issue.record("Unexpectedly didn't find text views.")
             return
         }
-        
+
         guard let container = lastParent as? DummyBackend.Container else {
             Issue.record("Parent of text views unexpectedly wasn't a container.")
             return
         }
-        
+
         #expect(container.children.count == 2)
-        
+
         guard
             container.children.count == 2,
             let (_, firstPosition) = container.children.first,
@@ -71,33 +71,33 @@ struct StackContextRendersDifferently {
             Issue.record("Unexpectedly failed to extract child positions.")
             return
         }
-        
+
         #expect(firstPosition.x == secondPosition.x)
     }
-    
+
     @Test func testHStack() {
         let backend = DummyBackend()
         let window = backend.createWindow(withDefaultSize: nil, id: "window")
         let environment = EnvironmentValues(backend: backend).with(\.window, window)
-        
+
         let view = HStack {
             TestView()
         }
-        
+
         let node = ViewGraphNode(for: view, backend: backend, environment: environment)
-        
+
         _ = node.computeLayout(
             proposedSize: .unspecified,
             environment: environment
         )
-        
+
         _ = node.commit()
-        
+
         let widget = node.widget
-        
+
         var lastParent: DummyBackend.Widget? = nil
         var children = widget.getChildren()
-        
+
         while children.count != 2 {
             guard let first = children.first else {
                 Issue.record("Unexpectedly didn't find children.")
@@ -106,57 +106,57 @@ struct StackContextRendersDifferently {
             lastParent = first
             children = first.getChildren()
         }
-        
+
         guard
             let _ = children.first as? DummyBackend.TextView,
             let _ = children.last as? DummyBackend.TextView
-                else {
+        else {
             Issue.record("Unexpectedly didn't find text views.")
             return
         }
-        
+
         guard let container = lastParent as? DummyBackend.Container else {
             Issue.record("Parent of text views unexpectedly wasn't a container.")
             return
         }
-        
+
         #expect(container.children.count == 2)
-        
+
         guard
             container.children.count == 2,
             let (_, firstPosition) = container.children.first,
             let (_, secondPosition) = container.children.last
-                else {
+        else {
             Issue.record("Unexpectedly failed to extract child positions.")
             return
         }
-        
+
         #expect(firstPosition.y == secondPosition.y)
     }
-    
+
     @Test func testZStack() {
         let backend = DummyBackend()
         let window = backend.createWindow(withDefaultSize: nil, id: "window")
         let environment = EnvironmentValues(backend: backend).with(\.window, window)
-        
+
         let view = ZStack {
             TestView()
         }
-        
+
         let node = ViewGraphNode(for: view, backend: backend, environment: environment)
-        
+
         _ = node.computeLayout(
             proposedSize: .unspecified,
             environment: environment
         )
-        
+
         _ = node.commit()
-        
+
         let widget = node.widget
-        
+
         var lastParent: DummyBackend.Widget? = nil
         var children = widget.getChildren()
-        
+
         while children.count != 2 {
             guard let first = children.first else {
                 Issue.record("Unexpectedly didn't find children.")
@@ -165,31 +165,31 @@ struct StackContextRendersDifferently {
             lastParent = first
             children = first.getChildren()
         }
-        
+
         guard
             let _ = children.first as? DummyBackend.TextView,
             let _ = children.last as? DummyBackend.TextView
-                else {
+        else {
             Issue.record("Unexpectedly didn't find text views.")
             return
         }
-        
+
         guard let container = lastParent as? DummyBackend.Container else {
             Issue.record("Parent of text views unexpectedly wasn't a container.")
             return
         }
-        
+
         #expect(container.children.count == 2)
-        
+
         guard
             container.children.count == 2,
             let (_, firstPosition) = container.children.first,
             let (_, secondPosition) = container.children.last
-                else {
+        else {
             Issue.record("Unexpectedly failed to extract child positions.")
             return
         }
-        
+
         #expect(firstPosition == secondPosition)
     }
 }


### PR DESCRIPTION
Resolves #728 

> [!IMPORTANT] 
> This is a breaking change for apps relying on the previous behaviour.

All changes are within the SwiftCrossUI target.

### EnvironmentValues
- added property `usesZStackLayout` to tell `computeStackLayout(_:)`,… to delegate to the ZStack variants
- added property `zStackContentAlignment`. The existing layoutAlignment property cannot be used as `Alignment` is not representable by `StackAlignment` and vice versa.

### LayoutSystem
- `computeStackLayout(_:)` now delegates to `computeZStackLayout(_:)` when `environment.usesZStackLayout` is `true`
- `commitStackLayout(_:)` now delegates to `commitZStackLayout(_:)` when `environment.usesZStackLayout` is `true`
- added `computeZStackLayout(_:)`. It is basically a copy of `computeStackLayout(_:)` with adjustments to make sense for ZStack context.
- added `computeZStackLayouts(_:)`. It is basically a copy of `computeStackLayouts(_:)` with adjustments to make sense for ZStack context.
- added `recomputeZStackCache(_:)`. It is basically a copy of `recomputeCache(_:)` with adjustments to make sense for ZStack context.
- added `commitZStackLayout(_:)`. It is basically a copy of `commitStackLayout(_:)` with adjustments to make sense for ZStack context.

#### How did I get to these changes?
I first copied each method. Then I removed the orientation, spacing and perpendicularOrientation variables as they are irrelevant for a ZStack. 

After seeing highlighted what used it, I removed or changed the rest. (e.g. [component: orientation] was always replaced). Min and max proposed size were replaced with 0,0 and infinity,infinity respectively as there is no axis to constrain that. In computeZStackLayout instead of adding result sizes, max is used (they’re not layed out horizontally or vertically so we only care about the biggest one to determine the size of the stack).

In commit I also replaced the positioning logic a new switch using the zStackContentAlignment.

redistributeSpaceOnCommit is always false inside of the ZStack layout functions, as the function the other ones use is not compatible with ZStack and I don’t know what reason to redistribute it for, as they don’t affect each others placement aside from the bounds of the ZStack they’re placed inside of.

I hope this is all correct, but the tests pass and Examples I tried also look correct to me, so I’m positive.

### HStack & VStack
sets the new `usesZStackLayout` to false on the environment, so the regular functions are used

### View
replaced `vStack.computeLayout(_:)`/`vStack.commit(_:)` with the respective functions on `body`.

### ZStack
replaced the logic in `computeLayout(_:)` and `commit(_:)` with the newly added `LayoutSystem` functions, like seen on `VStack` and `HStack`.

### Tests
- Added `StackContextRendersDifferently` Suite with one test for each stack type all using the namespaced `TestView`.

> [!NOTE]
> The alignment change in `commitZStackLayout(_:)` appears to be quite powerful lol. Only after changing it did the resulting position in the test case change.

### Things to consider:
I did not make any changes to `Spacer` and `Divider`. For `Spacer` it probably doesn’t matter, but `Dividider` will (afaict) layout differently depending on what the first 2D-Stack parent of `ZStack` is. If this is not desirable, please let me know, changing it to a certain orientation or hiding it entirely when `usesZStackLayout` should be no big deal.