### PR TITLE
Update benchmarks and add environment-heavy benchmark

### DIFF
--- a/Benchmarks/LayoutPerformanceBenchmark/EnvironmentHeavyView.swift
+++ b/Benchmarks/LayoutPerformanceBenchmark/EnvironmentHeavyView.swift
@@ -1,0 +1,144 @@
+import SwiftCrossUI
+import Foundation
+
+struct V1: View {
+    @Binding var toggleState: Bool
+    @Binding var date: Date
+    @Binding var option: String?
+
+    var body: some View {
+        VStack {
+            Toggle("Toggle", isOn: $toggleState)
+            DatePicker("DatePicker", selection: $date)
+            Picker(of: EnvironmentHeavyView.pickerOptions, selection: $option)
+            Button("Click me!") {}
+        }
+        .foregroundColor(.black)
+        .toggleStyle(.button)
+        .datePickerStyle(.automatic)
+        .pickerStyle(.menu)
+        .buttonStyle(.bordered)
+    }
+}
+
+struct H1: View {
+    @Binding var toggleState: Bool
+    @Binding var date: Date
+    @Binding var option: String?
+
+    var body: some View {
+        HStack {
+            Toggle("Toggle", isOn: $toggleState)
+            DatePicker("DatePicker", selection: $date)
+            Picker(of: EnvironmentHeavyView.pickerOptions, selection: $option)
+            Button("Click me!") {}
+
+            V1(toggleState: _toggleState, date: _date, option: _option)
+            V1(toggleState: _toggleState, date: _date, option: _option)
+            V1(toggleState: _toggleState, date: _date, option: _option)
+        }
+        .foregroundColor(.blue)
+        .toggleStyle(.checkbox)
+        .datePickerStyle(.compact)
+        .pickerStyle(.radioGroup)
+        .buttonStyle(.borderless)
+    }
+}
+
+struct V2: View {
+    @Binding var toggleState: Bool
+    @Binding var date: Date
+    @Binding var option: String?
+
+    var body: some View {
+        VStack {
+            Toggle("Toggle", isOn: $toggleState)
+            DatePicker("DatePicker", selection: $date)
+            Picker(of: EnvironmentHeavyView.pickerOptions, selection: $option)
+            Button("Click me!") {}
+
+            H1(toggleState: _toggleState, date: _date, option: _option)
+            H1(toggleState: _toggleState, date: _date, option: _option)
+            H1(toggleState: _toggleState, date: _date, option: _option)
+        }
+        .foregroundColor(.brown)
+        .toggleStyle(.switch)
+        .datePickerStyle(.graphical)
+        .pickerStyle(.segmented)
+        .buttonStyle(.plain)
+    }
+}
+
+struct H2: View {
+    @Binding var toggleState: Bool
+    @Binding var date: Date
+    @Binding var option: String?
+
+    var body: some View {
+        VStack {
+            Toggle("Toggle", isOn: $toggleState)
+            DatePicker("DatePicker", selection: $date)
+            Picker(of: EnvironmentHeavyView.pickerOptions, selection: $option)
+            Button("Click me!") {}
+
+            V2(toggleState: _toggleState, date: _date, option: _option)
+            V2(toggleState: _toggleState, date: _date, option: _option)
+            V2(toggleState: _toggleState, date: _date, option: _option)
+        }
+        .foregroundColor(.cyan)
+        .toggleStyle(.button)
+        .datePickerStyle(.automatic)
+        .pickerStyle(.wheel)
+        .buttonStyle(.bordered)
+    }
+}
+
+struct V3: View {
+    @Binding var toggleState: Bool
+    @Binding var date: Date
+    @Binding var option: String?
+
+    var body: some View {
+        VStack {
+            Toggle("Toggle", isOn: $toggleState)
+            DatePicker("DatePicker", selection: $date)
+            Picker(of: EnvironmentHeavyView.pickerOptions, selection: $option)
+            Button("Click me!") {}
+
+            H2(toggleState: _toggleState, date: _date, option: _option)
+            H2(toggleState: _toggleState, date: _date, option: _option)
+            H2(toggleState: _toggleState, date: _date, option: _option)
+        }
+        .foregroundColor(.gray)
+        .toggleStyle(.checkbox)
+        .datePickerStyle(.compact)
+        .pickerStyle(.menu)
+        .buttonStyle(.borderless)
+    }
+}
+
+struct EnvironmentHeavyView: TestCaseView {
+    @State var toggleState = true
+    @State var date = Date()
+    @State var option: String?
+
+    static let pickerOptions = ["foo", "bar", "baz", "qux"]
+
+    var body: some View {
+        HStack {
+            Toggle("Toggle", isOn: $toggleState)
+            DatePicker("DatePicker", selection: $date)
+            Picker(of: EnvironmentHeavyView.pickerOptions, selection: $option)
+            Button("Click me!") {}
+
+            V3(toggleState: $toggleState, date: $date, option: $option)
+            V3(toggleState: $toggleState, date: $date, option: $option)
+            V3(toggleState: $toggleState, date: $date, option: $option)
+        }
+        .foregroundColor(.green)
+        .toggleStyle(.switch)
+        .datePickerStyle(.graphical)
+        .pickerStyle(.radioGroup)
+        .buttonStyle(.plain)
+    }
+}

--- a/Benchmarks/LayoutPerformanceBenchmark/LayoutPerformanceBenchmark.swift
+++ b/Benchmarks/LayoutPerformanceBenchmark/LayoutPerformanceBenchmark.swift
@@ -1,5 +1,5 @@
 import Benchmark
-import SwiftCrossUI
+@_spi(Backends) import SwiftCrossUI
 import DummyBackend
 import Foundation
 
@@ -77,6 +77,11 @@ struct Benchmarks {
             of: ScrollableMessageListView.self,
             ProposedViewSize(800, 800),
             "message list"
+        )
+        benchmarkLayout(
+            of: EnvironmentHeavyView.self,
+            ProposedViewSize(800, 800),
+            "environment-heavy view"
         )
 
         #if BENCHMARK_VIZ

--- a/Benchmarks/LayoutPerformanceBenchmark/ScrollableMessageListView.swift
+++ b/Benchmarks/LayoutPerformanceBenchmark/ScrollableMessageListView.swift
@@ -64,10 +64,11 @@ struct ScrollableMessageListView: TestCaseView {
         )
     }
 
-    struct Message {
+    struct Message: Identifiable {
         var author: Author
         var content: String
         var time: String
+        var id: Int
     }
 
     static func generateMessages(_ count: Int) -> [Message] {
@@ -78,7 +79,8 @@ struct ScrollableMessageListView: TestCaseView {
             let message = Message(
                 author: authors[i % authors.count],
                 content: sentences[i % sentences.count],
-                time: times[i % times.count]
+                time: times[i % times.count],
+                id: i
             )
             messages.append(message)
         }

--- a/Sources/DummyBackend/DummyBackend.swift
+++ b/Sources/DummyBackend/DummyBackend.swift
@@ -7,8 +7,10 @@ public final class DummyBackend:
     BackendFeatures.CornerRadius,
     BackendFeatures.Tables,
     BackendFeatures.Colors,
-    BackendFeatures.Windowing
+    BackendFeatures.Windowing,
+    BackendFeatures.DatePickers
 {
+
     public class Window {
         static let defaultSize = SIMD2<Int>(400, 200)
 
@@ -257,6 +259,28 @@ public final class DummyBackend:
         }
     }
 
+    public class DatePicker: Widget {
+        var style: DatePickerStyle = .automatic
+        var value = Date()
+        var range = Date.distantPast ... Date.distantFuture
+        var components: DatePickerComponents = .init(rawValue: 0)
+        var onChange: ((Date) -> Void)?
+        var enabled = true
+    }
+
+    public class Picker: Widget {
+        let style: BackendPickerStyle
+        var selectedIndex: Int?
+        var options: [String] = []
+        var onChange: ((Int?) -> Void)?
+        var enabled = true
+
+        init(style: BackendPickerStyle) {
+            self.style = style
+            super.init()
+        }
+    }
+
     public var defaultTableRowContentHeight = 10
     public var defaultTableCellVerticalPadding = 10
     public var defaultPaddingAmount = 10
@@ -265,9 +289,15 @@ public final class DummyBackend:
     public var requiresImageUpdateOnScaleFactorChange = false
     public var deviceClass = DeviceClass.desktop
     public var supportsMultipleWindows = true
-    public var supportedPickerStyles: [BackendPickerStyle] = []
+    public var supportedPickerStyles: [BackendPickerStyle] = [
+        .menu,
+        .radioGroup,
+        .segmented,
+        .wheel
+    ]
     public let canOverrideWindowColorScheme = true
     public let restoresWindowFrames = false
+    public let supportedDatePickerStyles: [DatePickerStyle] = [.automatic, .compact, .graphical]
 
     public var incomingURLHandler: ((URL) -> Void)?
     public var appPhase = AppPhase.active
@@ -776,29 +806,52 @@ public final class DummyBackend:
         getContent(ofTextField: secureField)
     }
 
-    // MARK: - Unimplemented Features
-    // FIXME: Implement them so we can test them
+    public func createDatePicker() -> Widget {
+        DatePicker()
+    }
 
-    public func createPicker(style: SwiftCrossUI.BackendPickerStyle) -> Widget {
-        fatalError("\(Self.self): \(#function) not implemented")
+    public func updateDatePicker(
+        _ datePicker: Widget,
+        environment: EnvironmentValues,
+        date: Date,
+        range: ClosedRange<Date>,
+        components: DatePickerComponents,
+        onChange: @escaping (Date) -> Void
+    ) {
+        let datePicker = datePicker as! DatePicker
+        datePicker.style = environment.datePickerStyle
+        datePicker.value = date
+        datePicker.range = range
+        datePicker.components = components
+        datePicker.onChange = onChange
+        datePicker.enabled = environment.isEnabled
+    }
+
+    public func createPicker(style: BackendPickerStyle) -> Widget {
+        Picker(style: style)
     }
 
     public func updatePicker(
         _ picker: Widget,
         options: [String],
-        environment: SwiftCrossUI.EnvironmentValues,
+        environment: EnvironmentValues,
         onChange: @escaping (Int?) -> Void
     ) {
-        fatalError("\(Self.self): \(#function) not implemented")
+        let picker = picker as! Picker
+        picker.options = options
+        picker.onChange = onChange
+        picker.enabled = environment.isEnabled
     }
 
     public func setSelectedOption(
         ofPicker picker: Widget,
         to selectedOption: Int?
     ) {
-        fatalError("\(Self.self): \(#function) not implemented")
+        (picker as! Picker).selectedIndex = selectedOption
     }
 
+    // MARK: - Unimplemented Features
+    // FIXME: Implement them so we can test them
     public func createProgressBar() -> Widget {
         fatalError("\(Self.self): \(#function) not implemented")
     }


### PR DESCRIPTION
Closes #731 

Sometimes, a negative result is still a result. On my MacBook Air, the new benchmark takes about 140ms when the backing storage is `Dictionary`, and about 150ms when the backing storage is `TreeDictionary`. The grid benchmark also performs worse with `TreeDictionary` than with `Dictionary`, but by a much smaller margin. Therefore, I am closing #731 without updating `EnvironmentValues`.

I did have to make some minor adjustments to the existing benchmark files, as they were a bit out of date.