### PR TITLE
Fix Button._asMenuItems

### DIFF
--- a/Scripts/test.sh
+++ b/Scripts/test.sh
@@ -5,4 +5,4 @@ cd "$(dirname "$0")"/../
 # `swift test` builds all targets in the package (even those not depended upon
 # by any test targets), which leads to `swift test` on its own being broken
 # for SwiftCrossUI
-swift test --test-product swift-cross-uiPackageTests
+swift test --test-product swift-cross-uiPackageTests $@

--- a/Sources/DummyBackend/DummyBackend+AttachedMenus.swift
+++ b/Sources/DummyBackend/DummyBackend+AttachedMenus.swift
@@ -1,0 +1,33 @@
+@_spi(Backends) import SwiftCrossUI
+
+extension DummyBackend: BackendFeatures.AttachedMenus {
+    public class Menu {
+        public var content: ResolvedMenu
+
+        public init() {
+            content = ResolvedMenu(items: [])
+        }
+    }
+
+    public func createPopoverMenu() -> Menu {
+        Menu()
+    }
+
+    public func updatePopoverMenu(
+        _ menu: Menu,
+        content: ResolvedMenu,
+        environment: EnvironmentValues
+    ) {
+        menu.content = content
+    }
+
+    public func updateButton(
+        _ button: Widget,
+        label: String,
+        menu: Menu,
+        environment: EnvironmentValues
+    ) {
+        updateSimpleButton(button, label: label, environment: environment, action: {})
+        (button as! SimpleButton).menu = menu
+    }
+}

--- a/Sources/DummyBackend/DummyBackend.swift
+++ b/Sources/DummyBackend/DummyBackend.swift
@@ -80,6 +80,7 @@ public final class DummyBackend:
         public var label = ""
         public var font: Font.Resolved?
         public var action: (() -> Void)?
+        public var menu: Menu?
 
         /// Menu sizes its button widget through `naturalSize(of:)`, so leaving
         /// this at zero renders zero-sized menu buttons.

--- a/Sources/SwiftCrossUI/Views/Button.swift
+++ b/Sources/SwiftCrossUI/Views/Button.swift
@@ -133,11 +133,13 @@ extension Button: TypeSafeView {
         _ = children.child0.commit()
         backend.setSize(of: widget, to: layout.size.vector)
     }
-}
 
-@MainActor
-extension Button where Label == TupleView1<Text> {
     public var _asMenuItems: [MenuItem] {
-        [.button(self)]
+        if let self = self as? Button<TupleView1<Text>> {
+            return [.button(self)]
+        } else {
+            // TODO(stackotter): Figure out a better fallback for non-text buttons in menus
+            return body._asMenuItems
+        }
     }
 }

--- a/Tests/SwiftCrossUITests/Helpers/ViewGraphHelpers.swift
+++ b/Tests/SwiftCrossUITests/Helpers/ViewGraphHelpers.swift
@@ -1,0 +1,36 @@
+import DummyBackend
+@testable @_spi(Backends) import SwiftCrossUI
+
+enum ViewGraphHelpers {
+    @MainActor
+    static let backend = DummyBackend()
+
+    @MainActor
+    static let window = backend.createWindow(withDefaultSize: nil, id: "window")
+
+    @MainActor
+    static let environment = EnvironmentValues(backend: backend).with(\.window, window)
+
+    @MainActor
+    static func computeLayout<V: View>(
+        of view: V,
+        proposedSize: ProposedViewSize = .unspecified
+    ) -> ViewLayoutResult {
+        let node = ViewGraphNode(for: view, backend: backend, environment: environment)
+        return node.computeLayout(
+            proposedSize: proposedSize,
+            environment: environment
+        )
+    }
+
+    @MainActor
+    static func committedNode<V: View>(
+        for view: V,
+        proposedSize: ProposedViewSize = .unspecified
+    ) -> ViewGraphNode<V, DummyBackend> {
+        let node = ViewGraphNode(for: view, backend: backend, environment: environment)
+        _ = node.computeLayout(proposedSize: proposedSize, environment: environment)
+        _ = node.commit()
+        return node
+    }
+}

--- a/Tests/SwiftCrossUITests/MenuTests.swift
+++ b/Tests/SwiftCrossUITests/MenuTests.swift
@@ -1,0 +1,39 @@
+import Testing
+
+import DummyBackend
+@testable @_spi(Backends) import SwiftCrossUI
+
+@Suite("Menu tests")
+struct MenuTests {
+    @MainActor
+    @Test(
+        "Ensure buttons encode to menu items correctly",
+        .bug("https://github.com/moreSwift/swift-cross-ui/issues/747")
+    )
+    func buttonMenuItemEncoding() throws {
+        let labels = [
+            "Button1",
+            "Button2"
+        ]
+        let view = Menu("Menu") {
+            Button(labels[0]) {}
+            Button(action: {}) {
+                Text(labels[1])
+            }
+        }
+
+        let node = ViewGraphHelpers.committedNode(for: view)
+
+        let button = try #require(node.widget as? DummyBackend.SimpleButton)
+        let menu = try #require(button.menu)
+        for (i, item) in menu.content.items.enumerated() {
+            switch item {
+                case .button(let label, let action):
+                    #expect(label == labels[i])
+                    #expect(action != nil)
+                default:
+                    Issue.record("Expected button, got \(item)")
+            }
+        }
+    }
+}

--- a/Tests/SwiftCrossUITests/StackLayoutTests.swift
+++ b/Tests/SwiftCrossUITests/StackLayoutTests.swift
@@ -5,17 +5,6 @@ import DummyBackend
 
 @Suite("Testing for stack layouts")
 struct StackLayoutTests {
-    let backend: DummyBackend
-    let window: DummyBackend.Window
-    let environment: EnvironmentValues
-
-    @MainActor
-    init() {
-        backend = DummyBackend()
-        window = backend.createWindow(withDefaultSize: nil, id: "window")
-        environment = EnvironmentValues(backend: backend).with(\.window, window)
-    }
-
     @MainActor
     @Test("Empty ScrollView should still be greedy in stack (#328)")
     func emptyScrollViewInStack() {
@@ -25,7 +14,10 @@ struct StackLayoutTests {
         }
 
         let height = 200.0
-        let result = computeLayout(of: view, proposedSize: ProposedViewSize(100, height))
+        let result = ViewGraphHelpers.computeLayout(
+            of: view,
+            proposedSize: ProposedViewSize(100, height)
+        )
 
         #expect(result.size.height == height)
     }
@@ -39,7 +31,10 @@ struct StackLayoutTests {
             Text("Dummy")
         }.fixedSize()
 
-        let node = committedNode(for: view, proposedSize: ProposedViewSize(200, 200))
+        let node = ViewGraphHelpers.committedNode(
+            for: view,
+            proposedSize: ProposedViewSize(200, 200)
+        )
 
         let fixedSizeWidget = node.widget.getChildren()[0]
         let children = fixedSizeWidget.getChildren()
@@ -64,43 +59,20 @@ struct StackLayoutTests {
             Text(strings[1])
         }
 
-        let lineHeight = environment.resolvedFont.lineHeight
+        let lineHeight = ViewGraphHelpers.environment.resolvedFont.lineHeight
 
-        let textResults = strings.map(Text.init(_:)).map { computeLayout(of: $0) }
+        let textResults = strings.map(Text.init(_:)).map {
+            ViewGraphHelpers.computeLayout(of: $0)
+        }
         let minimumWidthWithoutWrapping = textResults.map(\.size.vector.x).reduce(0, +)
         let proposedSize = ProposedViewSize(
             Double(minimumWidthWithoutWrapping),
             lineHeight * 2
         )
-        let result = computeLayout(of: view, proposedSize: proposedSize)
+        let result = ViewGraphHelpers.computeLayout(of: view, proposedSize: proposedSize)
 
         // No wrapping, and perfect fit
-        #expect(result.size.height == environment.resolvedFont.lineHeight)
+        #expect(result.size.height == ViewGraphHelpers.environment.resolvedFont.lineHeight)
         #expect(result.size.vector.x == minimumWidthWithoutWrapping)
-    }
-
-    // MARK: Helpers
-
-    @MainActor
-    func computeLayout<V: View>(
-        of view: V,
-        proposedSize: ProposedViewSize = .unspecified
-    ) -> ViewLayoutResult {
-        let node = ViewGraphNode(for: view, backend: backend, environment: environment)
-        return node.computeLayout(
-            proposedSize: proposedSize,
-            environment: environment
-        )
-    }
-
-    @MainActor
-    func committedNode<V: View>(
-        for view: V,
-        proposedSize: ProposedViewSize = .unspecified
-    ) -> ViewGraphNode<V, DummyBackend> {
-        let node = ViewGraphNode(for: view, backend: backend, environment: environment)
-        _ = node.computeLayout(proposedSize: proposedSize, environment: environment)
-        _ = node.commit()
-        return node
     }
 }


### PR DESCRIPTION
This PR fixes #747 and introduces a test to guard against similar regressions in future.

As part of the test implementation I ended up tackling part of #740 (i.e. moving 1StackLayoutTests`' helpers into a separate reusable helper enum).

#747 explains the cause of the issue and why these changes resolve the issue.