### PR TITLE
Drop the SwiftSyntax dependency from the SwiftCrossUI runtime target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -208,13 +208,6 @@ let package = Package(
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Mutex", package: "swift-mutex"),
 
-                // This import is purely required to fix a linker issue and a plugin build
-                // error that occur on macOS when building for non-Android platforms now that
-                // we've added the AndroidBackend. Providing the '--disable-experimental-prebuilts'
-                // flag when building SwiftCrossUI apps doesn't seem to be sufficient to fix
-                // the issues, even though I would've thought that was the effect that adding
-                // this dependency has.
-                .product(name: "SwiftSyntax", package: "swift-syntax"),
             ],
             exclude: [
                 "Builders/ViewBuilder.swift.gyb",


### PR DESCRIPTION
The `SwiftCrossUI` target depends on `SwiftSyntax` with a comment explaining it
exists purely to work around a macOS linker issue and plugin build error that
appeared when the AndroidBackend was added, noting that
`--disable-experimental-prebuilts` did not seem sufficient.

No source in the runtime target imports SwiftSyntax. The macros are declared
with `#externalMacro(module: "SwiftCrossUIMacrosPlugin", ...)`, which the
compiler plugin resolves at build time and never links into the app. SwiftPM
still links the library, so it ships in every application binary.

## Measurements

A small SwiftCrossUI app (one window, no images), Swift 6.2.3, macOS 26,
`--arch arm64 -c release`, stripped with `strip -rSTx`:

| | size |
|---|---|
| with SwiftSyntax | 8.8 MB |
| without | **4.3 MB** |

Attributing `__text` by symbol, SwiftSyntax was 2.6 MB of 5.6 MB, about 45%.
Removing the dependency also drops the associated metadata and `__LINKEDIT`,
hence the larger total saving. Afterwards `nm` reports zero SwiftSyntax
symbols, and the app builds, links and runs unchanged.

Measured against this PR's base (`99d715da`), not against an older tag.

## Caveats

I only tested **macOS / arm64**. The workaround was introduced for an
Android-related build failure, and I have no Android toolchain to check
against, so I cannot say whether it is still needed there. I was unable to
reproduce the original linker error on this toolchain at all, which is why I
am proposing removal rather than a narrower change.

If it does turn out to still be required for Android, a platform condition
would keep the workaround where it is needed without costing every other
platform ~4.5 MB per binary, for example:

```swift
.product(name: "SwiftSyntax", package: "swift-syntax", condition: .when(platforms: [.android])),
```

Happy to rework it that way, or to close this if the dependency is load-bearing
in a way I have missed.
