### PR TITLE
Added support for multilineTextAlignment to android

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "originHash" : "9a3fc8da1ee0b5be91458b83c5c4221ce51d024f1041444de65ee5e090c81b38",
   "pins" : [
     {
+      "identity" : "androidkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/moreSwift/AndroidKit",
+      "state" : {
+        "revision" : "d5142b5a9b90fa940be54a2a41d7fd5842f21111",
+        "version" : "0.8.1"
+      }
+    },
+    {
       "identity" : "jpeg",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stackotter/jpeg",
@@ -26,6 +35,15 @@
       "state" : {
         "revision" : "5f745a17b9a5c2a4283f17c2cde4517610ab5f99",
         "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-android-native",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-android-sdk/swift-android-native.git",
+      "state" : {
+        "revision" : "5f71c1584b3cbe3842d335ebb4d7b545205d9945",
+        "version" : "2.1.0"
       }
     },
     {
@@ -83,6 +101,24 @@
       }
     },
     {
+      "identity" : "swift-java",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stackotter/swift-java",
+      "state" : {
+        "revision" : "e04c0ed6af98936ca6300e94be9a19869df418a2",
+        "version" : "0.5.1"
+      }
+    },
+    {
+      "identity" : "swift-java-jni-core",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-java-jni-core",
+      "state" : {
+        "revision" : "b440a0be98381550cf189c903782e817619ffa05",
+        "version" : "0.5.1"
+      }
+    },
+    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
@@ -110,6 +146,15 @@
       }
     },
     {
+      "identity" : "swift-subprocess",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-subprocess.git",
+      "state" : {
+        "revision" : "11633673a41f509f8945f23c96c7acd4adafd679",
+        "version" : "0.5.0"
+      }
+    },
+    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
@@ -134,6 +179,24 @@
       "state" : {
         "revision" : "df7642fbb88e23a9cc1bbd366c7d6d3780fd0251",
         "version" : "0.2.1"
+      }
+    },
+    {
+      "identity" : "swiftjavalang",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stackotter/SwiftJavaLang.git",
+      "state" : {
+        "revision" : "000441db9284536a2af611745b82ec7653dca5bc",
+        "version" : "0.3.0"
+      }
+    },
+    {
+      "identity" : "swiftkotlin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stackotter/SwiftKotlin.git",
+      "state" : {
+        "revision" : "ad30daacb7e4666e1a56bfdd48498f5ac4ff081d",
+        "version" : "0.3.0"
       }
     },
     {

--- a/Sources/AndroidBackend/AndroidBackend+Fonts.swift
+++ b/Sources/AndroidBackend/AndroidBackend+Fonts.swift
@@ -14,6 +14,7 @@ extension AndroidBackend {
         var fontSize: Float
         var lineHeightPixels: Int32
         var typeface: AndroidKit.Typeface
+        var multilineTextAlignment: Int32
 
         func apply(to textView: AndroidKit.TextView) {
             let typedValue = try! JavaClass<AndroidKit.TypedValue>()
@@ -22,6 +23,7 @@ extension AndroidBackend {
             textView.setTextColor(color)
             textView.setTextSize(typedValue.COMPLEX_UNIT_SP, fontSize)
             textView.setLineHeight(lineHeightPixels)
+            textView.setGravity(multilineTextAlignment)
         }
     }
 
@@ -34,6 +36,15 @@ extension AndroidBackend {
             switch resolvedFont.design {
                 case .default: typefaceClass.DEFAULT
                 case .monospaced: typefaceClass.MONOSPACE
+            }
+
+        let gravityClass = try! JavaClass<AndroidKit.Gravity>()
+
+        let textAlignment =
+            switch environment.multilineTextAlignment {
+                case .leading: gravityClass.LEFT
+                case .center: gravityClass.CENTER_HORIZONTAL
+                case .trailing: gravityClass.RIGHT
             }
 
         let weightInt: Int32 =
@@ -67,7 +78,8 @@ extension AndroidBackend {
             color: colorInt,
             fontSize: Float(resolvedFont.pointSize),
             lineHeightPixels: lineHeightPixels,
-            typeface: typeface
+            typeface: typeface,
+            multilineTextAlignment: textAlignment
         )
     }
 
@@ -103,4 +115,9 @@ extension AndroidBackend {
             lineHeight: lineHeight
         )
     }
+}
+
+extension TextView {
+    @JavaMethod
+    open func setGravity(_ arg0: Int32)
 }


### PR DESCRIPTION
Resolves #749 

I added an extension to TextView to get access to the java method in AndroidBackend+Fonts, because I don’t think it should be in the main one, where create and update TextView are.

I also decided to map .leading and .trailing to left and right respectively instead of start and end, because as far as I can tell we don’t handle localization for multilineTextAlignment yet (at least not in the AppKitBackend) and consistency is more important here in my opinion.
<img width="479" height="898" alt="Screenshot 2026-09-06 at 12 58 37" src="https://github.com/user-attachments/assets/dce3a540-190c-47e0-81f4-0e39f0cea71d" />
<img width="523" height="942" alt="Screenshot 2026-09-06 at 12 58 40" src="https://github.com/user-attachments/assets/b18847e1-3fe9-4edd-8174-ff43adf366b5" />
<img width="523" height="942" alt="Screenshot 2026-09-06 at 12 58 46" src="https://github.com/user-attachments/assets/6bd6f205-b864-4b10-9c95-409288d63a4c" />

