### PR TITLE
Remove SwiftSyntax workaround (no longer necessary) (fixes #753)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -207,14 +207,6 @@ let package = Package(
                 .product(name: "ImageFormats", package: "swift-image-formats"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Mutex", package: "swift-mutex"),
-
-                // This import is purely required to fix a linker issue and a plugin build
-                // error that occur on macOS when building for non-Android platforms now that
-                // we've added the AndroidBackend. Providing the '--disable-experimental-prebuilts'
-                // flag when building SwiftCrossUI apps doesn't seem to be sufficient to fix
-                // the issues, even though I would've thought that was the effect that adding
-                // this dependency has.
-                .product(name: "SwiftSyntax", package: "swift-syntax"),
             ],
             exclude: [
                 "Builders/ViewBuilder.swift.gyb",


### PR DESCRIPTION
#753 brought to my attention that my strange SwiftSyntax workaround is no longer necessary. I do not enjoy the lack of respect that the issue author showed to our contributors, but LLM-generated issues put us in a strange spot: they're clearly against our policy, but there's a point where an issue becomes important enough that we should pay attention to it anyway.

I've spent the morning trying to reproduce the original issue (with the original offending commit etc), but it's rather difficult because at the time of the workaround AndroidKit had a bunch of `main` dependencies which now resolve to different commits. I have not managed to reproduce the issue with any of the Swift toolchains that I have tried, and neither could the issue author's LLM of choice.

I believe that one of our dependencies has fixed the issue since the initial workaround (either intentionally or inadvertently), so we can now safely remove the workaround.

LLM usage does strange things to some peoples' respect for fellow humans.