### PR TITLE
WinUIBackend: Fix Button rendering post-#590

### DIFF
--- a/Sources/WinUIBackend/WinUIBackend+Button.swift
+++ b/Sources/WinUIBackend/WinUIBackend+Button.swift
@@ -20,6 +20,12 @@ extension WinUIBackend {
         button.action = action
         button.buttonStyle = environment.resolvedButtonStyle.kind
         button.enabled = environment.isEnabled
+        switch environment.colorScheme {
+            case .light:
+                button.requestedTheme = .light
+            case .dark:
+                button.requestedTheme = .dark
+        }
     }
 
     public func buttonPadding(in environment: EnvironmentValues) -> SIMD2<Int> {

--- a/Sources/WinUIBackend/WinUIBackend+Button.swift
+++ b/Sources/WinUIBackend/WinUIBackend+Button.swift
@@ -38,20 +38,22 @@ extension WinUIBackend {
     public func defaultButtonStyle() -> ButtonStyle { .bordered }
 
     func measureBorderedButtonPadding() -> SIMD2<Int> {
-        if let borderedButtonPadding { return borderedButtonPadding }
+        if let borderedButtonPadding {
+            return borderedButtonPadding
+        }
 
-        let testString = "E"
         let dummyButton = Button()
-        let block = TextBlock()
-        block.text = testString
-        dummyButton.content = block
+        let placeholder = Canvas()
+        let placeholderSize = SIMD2<Double>(40, 40)
+        placeholder.width = placeholderSize.x
+        placeholder.height = placeholderSize.y
+        dummyButton.content = placeholder
 
         let buttonSize = Self.naturalSize(of: dummyButton)
-        let textSize = Self.naturalSize(of: block)
 
         let result = SIMD2(
-            Int(buttonSize.x - textSize.x),
-            Int(buttonSize.y - textSize.y)
+            buttonSize.x - Int(placeholderSize.x),
+            buttonSize.y - Int(placeholderSize.y)
         )
 
         borderedButtonPadding = result

--- a/Sources/WinUIBackend/WinUIBackend.swift
+++ b/Sources/WinUIBackend/WinUIBackend.swift
@@ -963,10 +963,12 @@ public final class WinUIBackend:
         action: @escaping () -> Void
     ) {
         let button = button as! WinUI.Button
-        let block = TextBlock()
+
+        let block = createTextView() as! WinUI.TextBlock
         block.text = label
         button.content = block
         environment.apply(to: block)
+
         environment.apply(to: button)
         internalState.buttonClickActions[ObjectIdentifier(button)] = action
     }
@@ -995,10 +997,12 @@ public final class WinUIBackend:
         environment: EnvironmentValues
     ) {
         let button = button as! WinUI.Button
-        let block = TextBlock()
+
+        let block = createTextView() as! WinUI.TextBlock
         block.text = label
         button.content = block
         environment.apply(to: block)
+
         environment.apply(to: button)
         button.flyout = menu
     }


### PR DESCRIPTION
This PR fixes #756. It also updates the button implementation introduced in #590 to correctly apply the environment's `colorScheme` to the underlying button.

#756 goes into more detail about the cause of the issue.

The changes that I made to `measureBorderedButtonPadding` didn't end up being necessary, but I've left them in because it feels a bit nicer using a blank square as a placeholder to measure the padding, rather than involving text layout and all the potential issues that can come with text layout.