### PR TITLE
Adds linelimit support to dummybackend

### DIFF
--- a/Sources/DummyBackend/DummyBackend.swift
+++ b/Sources/DummyBackend/DummyBackend.swift
@@ -574,7 +574,8 @@ public final class DummyBackend:
             of: text,
             displayedWith: environment.resolvedFont,
             proposedWidth: proposedWidth,
-            proposedHeight: proposedHeight
+            proposedHeight: proposedHeight,
+            lineLimit: environment.lineLimitSettings
         )
     }
 
@@ -583,7 +584,8 @@ public final class DummyBackend:
         of text: String,
         displayedWith font: Font.Resolved,
         proposedWidth: Int?,
-        proposedHeight: Int?
+        proposedHeight: Int?,
+        lineLimit: LineLimit? = nil,
     ) -> SIMD2<Int> {
         let lineHeight = Int(font.lineHeight)
         let characterHeight = Int(font.pointSize)
@@ -600,6 +602,13 @@ public final class DummyBackend:
         var lineCount = (text.count + charactersPerLine - 1) / charactersPerLine
         if let proposedHeight {
             lineCount = min(max(1, proposedHeight / lineHeight), lineCount)
+        }
+
+        if let lineLimit {
+            lineCount = min(lineCount, lineLimit.limit)
+            if lineLimit.reservesSpace {
+                lineCount = max(lineCount, lineLimit.limit)
+            }
         }
 
         return SIMD2(


### PR DESCRIPTION
resolves #502 
first takes the min of lineCount an lineLimit.limit to, well, limit.
if it should reserve space it takes the max of the limited value and the limit.

I didn’t create a test cause it would feel a bit pointless to test a test. But there’s an issue for it and now it’s resolved lol